### PR TITLE
Explicit `NA`-handling :hammer_and_wrench: 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,8 @@ po/*~
 rsconnect/
 .Rproj.user
 
-# playground
-playground/
+# sandbox
+sandbox/
 docs
 inst/doc
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SLmetrics
 Title: Machine Learning Performance Evaluation on Steroids
-Version: 0.1-0
+Version: 0.1-1
 Authors@R: c(
     person(
       given   = "Serkan", 

--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -15,11 +15,43 @@ knitr::opts_chunk$set(
 set.seed(1903) 
 ```
 
-# Version 0.1-0
+# Version 0.1-1
 
-> Version 0.1-0 is considered pre-release of {SLmetrics}. We do not
+> Version 0.1-1 is considered pre-release of {SLmetrics}. We do not
 > expect any breaking changes, unless a major bug/issue is reported and its nature
 > forces breaking changes.
+
+## General
+
+* **Backend changes:** All pair-wise metrics arer moved from {Rcpp} to C++, this have reduced execution time by half. All pair-wise metrics are now faster.
+
+## Improvements
+
+* **NA-controls:** All pair-wise metrics that doesn't have a `micro`-argument were handling missing values as according to C++ and {Rcpp} internals. See [Issue](https://github.com/serkor1/SLmetrics/issues/8). Thank you @EmilHvitfeldt for pointing this out. This has now been fixed so functions uses an `na.rm`-argument to explicitly control for this. See below,
+
+```{r}
+# 1) define factors
+actual    <- factor(c("no", "yes"))
+predicted <- factor(c(NA, "no"))
+
+# 2) accuracy with na.rm = TRUE
+SLmetrics::accuracy(
+    actual    = actual,
+    predicted = predicted,
+    na.rm     = TRUE
+)
+
+# 2) accuracy with na.rm = FALSE
+SLmetrics::accuracy(
+    actual    = actual,
+    predicted = predicted,
+    na.rm     = FALSE
+)
+```
+
+
+
+# Version 0.1-0
 
 ## General
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,55 @@
 
-# Version 0.1-0
+# Version 0.1-1
 
-> Version 0.1-0 is considered pre-release of {SLmetrics}. We do not
+> Version 0.1-1 is considered pre-release of {SLmetrics}. We do not
 > expect any breaking changes, unless a major bug/issue is reported and
 > its nature forces breaking changes.
+
+## General
+
+  - **Backend changes:** All pair-wise metrics arer moved from {Rcpp} to
+    C++, this have reduced execution time by half. All pair-wise metrics
+    are now faster.
+
+## Improvements
+
+  - **NA-controls:** All pair-wise metrics that doesn’t have a
+    `micro`-argument were handling missing values as according to C++
+    and {Rcpp} internals. See
+    [Issue](https://github.com/serkor1/SLmetrics/issues/8). Thank you
+    @EmilHvitfeldt for pointing this out. This has now been fixed so
+    functions uses an `na.rm`-argument to explicitly control for this.
+    See below,
+
+<!-- end list -->
+
+``` r
+# 1) define factors
+actual    <- factor(c("yes", "no"))
+predicted <- factor(c(NA, "no"))
+
+# 2) accuracy with na.rm = TRUE
+SLmetrics::accuracy(
+    actual    = actual,
+    predicted = predicted,
+    na.rm     = TRUE
+)
+```
+
+    #> [1] 1
+
+``` r
+# 2) accuracy with na.rm = FALSE
+SLmetrics::accuracy(
+    actual    = actual,
+    predicted = predicted,
+    na.rm     = FALSE
+)
+```
+
+    #> [1] NaN
+
+# Version 0.1-0
 
 ## General
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -482,15 +482,15 @@ zerooneloss.cmatrix <- function(x, ...) {
 #' @rdname rsq
 #' @method rsq numeric
 #' @export
-rsq.numeric <- function(actual, predicted, k = 0, ...) {
-    .Call(`_SLmetrics_rsq`, actual, predicted, k)
+rsq.numeric <- function(actual, predicted, k = 0, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_rsq`, actual, predicted, k, na_rm = na.rm)
 }
 
 #' @rdname ccc
 #' @method ccc numeric
 #' @export
-ccc.numeric <- function(actual, predicted, correction = FALSE, w = NULL, ...) {
-    .Call(`_SLmetrics_ccc`, actual, predicted, correction, w)
+ccc.numeric <- function(actual, predicted, correction = FALSE, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_ccc`, actual, predicted, correction, w, na_rm = na.rm)
 }
 
 #' @rdname huberloss
@@ -503,50 +503,50 @@ huberloss.numeric <- function(actual, predicted, delta = 1.0, w = NULL, na.rm = 
 #' @rdname mae
 #' @method mae numeric
 #' @export
-mae.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_mae`, actual, predicted, w)
+mae.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_mae`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname mape
 #' @method mape numeric
 #' @export
-mape.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_mape`, actual, predicted, w)
+mape.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_mape`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname mpe
 #' @method mpe numeric
 #' @export
-mpe.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_mpe`, actual, predicted, w)
+mpe.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_mpe`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname mse
 #' @method mse numeric
 #' @export
-mse.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_mse`, actual, predicted, w)
+mse.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_mse`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname pinball
 #' @method pinball numeric
 #' @export
-pinball.numeric <- function(actual, predicted, alpha = 0.5, deviance = FALSE, w = NULL, ...) {
-    .Call(`_SLmetrics_pinball`, actual, predicted, alpha, deviance, w)
+pinball.numeric <- function(actual, predicted, alpha = 0.5, deviance = FALSE, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_pinball`, actual, predicted, alpha, deviance, w, na_rm = na.rm)
 }
 
 #' @rdname rae
 #' @method rae numeric
 #' @export
-rae.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_rae`, actual, predicted, w)
+rae.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_rae`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname rrmse
 #' @method rrmse numeric
 #' @export
-rrmse.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_rrmse`, actual, predicted, w)
+rrmse.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_rrmse`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname rmse
@@ -566,7 +566,7 @@ rmsle.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
 #' @rdname smape
 #' @method smape numeric
 #' @export
-smape.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_smape`, actual, predicted, w)
+smape.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_smape`, actual, predicted, w, na_rm = na.rm)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@
 #' @method accuracy factor
 #'
 #' @export
-accuracy.factor <- function(actual, predicted, ...) {
-    .Call(`_SLmetrics_accuracy`, actual, predicted)
+accuracy.factor <- function(actual, predicted, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_accuracy`, actual, predicted, na_rm = na.rm)
 }
 
 #' @rdname accuracy

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -496,8 +496,8 @@ ccc.numeric <- function(actual, predicted, correction = FALSE, w = NULL, ...) {
 #' @rdname huberloss
 #' @method huberloss numeric
 #' @export
-huberloss.numeric <- function(actual, predicted, delta = 1.0, w = NULL, ...) {
-    .Call(`_SLmetrics_huberloss`, actual, predicted, delta, w)
+huberloss.numeric <- function(actual, predicted, delta = 1.0, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_huberloss`, actual, predicted, delta, w, na_rm = na.rm)
 }
 
 #' @rdname mae
@@ -552,15 +552,15 @@ rrmse.numeric <- function(actual, predicted, w = NULL, ...) {
 #' @rdname rmse
 #' @method rmse numeric
 #' @export
-rmse.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_rmse`, actual, predicted, w)
+rmse.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_rmse`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname rmsle
 #' @method rmsle numeric
 #' @export
-rmsle.numeric <- function(actual, predicted, w = NULL, ...) {
-    .Call(`_SLmetrics_rmsle`, actual, predicted, w)
+rmsle.numeric <- function(actual, predicted, w = NULL, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_rmsle`, actual, predicted, w, na_rm = na.rm)
 }
 
 #' @rdname smape

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -468,8 +468,8 @@ selectivity.cmatrix <- function(x, micro = NULL, na.rm = TRUE, ...) {
 #' @rdname zerooneloss
 #' @method zerooneloss factor
 #' @export
-zerooneloss.factor <- function(actual, predicted, ...) {
-    .Call(`_SLmetrics_zerooneloss`, actual, predicted)
+zerooneloss.factor <- function(actual, predicted, na.rm = FALSE, ...) {
+    .Call(`_SLmetrics_zerooneloss`, actual, predicted, na_rm = na.rm)
 }
 
 #' @rdname zerooneloss

--- a/R/S3_HuberLoss.R
+++ b/R/S3_HuberLoss.R
@@ -15,6 +15,7 @@
 #' @param predicted A <[numeric]>-vector of [length] \eqn{n}. The estimated (continuous) response variable.
 #' @param w A <[numeric]>-vector of [length] \eqn{n}. The weight assigned to each observation in the data. See [stats::weighted.mean()] for more details.
 #' @param delta A <[numeric]>-vector of [length] 1. 1 by default. The threshold value for switch between functions (see calculation).
+#' @param na.rm A <[logical]>-value of [length] \eqn{1}. [FALSE] by default. If [TRUE] NA values will be removed from the computation.
 #' @param ... Arguments passed into other methods.
 #'
 #' @section Calculation:

--- a/R/S3_specificity.R
+++ b/R/S3_specificity.R
@@ -16,8 +16,7 @@
 #' @param x A confusion matrix created by [table()] or [cmatrix()]
 #' @param micro A <[logical]>-value of [length] \eqn{1}. [NULL] by default. If [TRUE] it returns the
 #' micro average across all \eqn{k} classes, if [FALSE] it returns the macro average. Otherwise class wise performance evaluation.
-#' @param na.rm A <[logical]>-value of [length] \eqn{1}. [TRUE] by default. If [FALSE] [NA] values will be disregarded when `micro = FALSE`.
-#'
+#' @param na.rm A <[logical]>-value of [length] \eqn{1}. [FALSE] by default. If [TRUE] NA values will be removed from the computation.#'
 #' @details
 #'
 #' Consider a classification problem with three classes: `A`, `B`, and `C`. The actual vector of [factor()] values is defined as follows:

--- a/R/S3_specificity.R
+++ b/R/S3_specificity.R
@@ -16,7 +16,7 @@
 #' @param x A confusion matrix created by [table()] or [cmatrix()]
 #' @param micro A <[logical]>-value of [length] \eqn{1}. [NULL] by default. If [TRUE] it returns the
 #' micro average across all \eqn{k} classes, if [FALSE] it returns the macro average. Otherwise class wise performance evaluation.
-#' @param na.rm A <[logical]>-value of [length] \eqn{1}. [FALSE] by default. If [TRUE] NA values will be removed from the computation.#'
+#' @param na.rm A <[logical]>-value of [length] \eqn{1}. [FALSE] by default. If [TRUE] NA values will be removed from the computation.
 #' @details
 #'
 #' Consider a classification problem with three classes: `A`, `B`, and `C`. The actual vector of [factor()] values is defined as follows:

--- a/man/ROC.Rd
+++ b/man/ROC.Rd
@@ -20,7 +20,7 @@ micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro a
 
 \item{thresholds}{An optional <\link{numeric}>-vector of non-zero \link{length}. \link{NULL} by default.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/ROC.Rd
+++ b/man/ROC.Rd
@@ -20,7 +20,7 @@ micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro a
 
 \item{thresholds}{An optional <\link{numeric}>-vector of non-zero \link{length}. \link{NULL} by default.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/accuracy.Rd
+++ b/man/accuracy.Rd
@@ -6,7 +6,7 @@
 \alias{accuracy}
 \title{Compute the \eqn{\text{accuracy}}}
 \usage{
-\method{accuracy}{factor}(actual, predicted, ...)
+\method{accuracy}{factor}(actual, predicted, na.rm = FALSE, ...)
 
 \method{accuracy}{cmatrix}(x, ...)
 
@@ -16,6 +16,8 @@ accuracy(...)
 \item{actual}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
 
 \item{predicted}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/accuracy.Rd
+++ b/man/accuracy.Rd
@@ -17,7 +17,7 @@ accuracy(...)
 
 \item{predicted}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/ccc.Rd
+++ b/man/ccc.Rd
@@ -6,7 +6,7 @@
 \alias{ccc}
 \title{Compute the \eqn{\text{concordance}} \eqn{\text{correlation}} \eqn{\text{coefficient}}}
 \usage{
-\method{ccc}{numeric}(actual, predicted, correction = FALSE, w = NULL, ...)
+\method{ccc}{numeric}(actual, predicted, correction = FALSE, w = NULL, na.rm = FALSE, ...)
 
 ccc(...)
 }
@@ -19,6 +19,8 @@ ccc(...)
 will be adjusted with \eqn{\frac{1-n}{n}}}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/dor.Rd
+++ b/man/dor.Rd
@@ -20,7 +20,7 @@ dor(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/dor.Rd
+++ b/man/dor.Rd
@@ -20,7 +20,7 @@ dor(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fbeta.Rd
+++ b/man/fbeta.Rd
@@ -22,7 +22,7 @@ fbeta(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fbeta.Rd
+++ b/man/fbeta.Rd
@@ -22,7 +22,7 @@ fbeta(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fdr.Rd
+++ b/man/fdr.Rd
@@ -20,7 +20,7 @@ fdr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fdr.Rd
+++ b/man/fdr.Rd
@@ -20,7 +20,7 @@ fdr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fer.Rd
+++ b/man/fer.Rd
@@ -20,7 +20,7 @@ fer(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fer.Rd
+++ b/man/fer.Rd
@@ -20,7 +20,7 @@ fer(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fpr.Rd
+++ b/man/fpr.Rd
@@ -29,7 +29,7 @@ fallout(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/fpr.Rd
+++ b/man/fpr.Rd
@@ -29,7 +29,7 @@ fallout(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/huberloss.Rd
+++ b/man/huberloss.Rd
@@ -5,7 +5,7 @@
 \alias{huberloss}
 \title{Compute the \eqn{\text{huber}} \eqn{\text{loss}}}
 \usage{
-\method{huberloss}{numeric}(actual, predicted, delta = 1, w = NULL, ...)
+\method{huberloss}{numeric}(actual, predicted, delta = 1, w = NULL, na.rm = FALSE, ...)
 
 huberloss(...)
 }
@@ -17,6 +17,8 @@ huberloss(...)
 \item{delta}{A <\link{numeric}>-vector of \link{length} 1. 1 by default. The threshold value for switch between functions (see calculation).}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/jaccard.Rd
+++ b/man/jaccard.Rd
@@ -38,7 +38,7 @@ tscore(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/jaccard.Rd
+++ b/man/jaccard.Rd
@@ -38,7 +38,7 @@ tscore(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/mae.Rd
+++ b/man/mae.Rd
@@ -5,7 +5,7 @@
 \alias{mae}
 \title{Compute the \eqn{\text{mean}} \eqn{\text{absolute}} \eqn{\text{error}}}
 \usage{
-\method{mae}{numeric}(actual, predicted, w = NULL, ...)
+\method{mae}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 mae(...)
 }
@@ -15,6 +15,8 @@ mae(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/mape.Rd
+++ b/man/mape.Rd
@@ -6,7 +6,7 @@
 \alias{mape}
 \title{Compute the \eqn{\text{mean}} \eqn{\text{absolute}} \eqn{\text{percentage}} \eqn{\text{error}}}
 \usage{
-\method{mape}{numeric}(actual, predicted, w = NULL, ...)
+\method{mape}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 mape(...)
 }
@@ -16,6 +16,8 @@ mape(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/mpe.Rd
+++ b/man/mpe.Rd
@@ -5,7 +5,7 @@
 \alias{mpe}
 \title{Compute the \eqn{\text{mean}} \eqn{\text{percentage}} \eqn{\text{error}}}
 \usage{
-\method{mpe}{numeric}(actual, predicted, w = NULL, ...)
+\method{mpe}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 mpe(...)
 }
@@ -15,6 +15,8 @@ mpe(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/mse.Rd
+++ b/man/mse.Rd
@@ -5,7 +5,7 @@
 \alias{mse}
 \title{Compute the \eqn{\text{mean}} \eqn{\text{squared}} \eqn{\text{error}}}
 \usage{
-\method{mse}{numeric}(actual, predicted, w = NULL, ...)
+\method{mse}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 mse(...)
 }
@@ -15,6 +15,8 @@ mse(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/nlr.Rd
+++ b/man/nlr.Rd
@@ -20,7 +20,7 @@ nlr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/nlr.Rd
+++ b/man/nlr.Rd
@@ -20,7 +20,7 @@ nlr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/npv.Rd
+++ b/man/npv.Rd
@@ -20,7 +20,7 @@ npv(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/npv.Rd
+++ b/man/npv.Rd
@@ -20,7 +20,7 @@ npv(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/pinball.Rd
+++ b/man/pinball.Rd
@@ -5,7 +5,15 @@
 \alias{pinball}
 \title{Compute the \eqn{\text{pinball}} \eqn{\text{loss}}}
 \usage{
-\method{pinball}{numeric}(actual, predicted, alpha = 0.5, deviance = FALSE, w = NULL, ...)
+\method{pinball}{numeric}(
+  actual,
+  predicted,
+  alpha = 0.5,
+  deviance = FALSE,
+  w = NULL,
+  na.rm = FALSE,
+  ...
+)
 
 pinball(...)
 }
@@ -19,6 +27,8 @@ pinball(...)
 \item{deviance}{A <\link{logical}>-value of \link{length} 1. \link{FALSE} by default. If \link{TRUE} the function returns the \eqn{D^2} loss.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/plr.Rd
+++ b/man/plr.Rd
@@ -20,7 +20,7 @@ plr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/plr.Rd
+++ b/man/plr.Rd
@@ -20,7 +20,7 @@ plr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/prROC.Rd
+++ b/man/prROC.Rd
@@ -19,7 +19,7 @@ micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro a
 
 \item{thresholds}{An optional <\link{numeric}>-vector of non-zero \link{length}. \link{NULL} by default.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/prROC.Rd
+++ b/man/prROC.Rd
@@ -19,7 +19,7 @@ micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro a
 
 \item{thresholds}{An optional <\link{numeric}>-vector of non-zero \link{length}. \link{NULL} by default.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/precision.Rd
+++ b/man/precision.Rd
@@ -29,7 +29,7 @@ ppv(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/precision.Rd
+++ b/man/precision.Rd
@@ -29,7 +29,7 @@ ppv(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/rae.Rd
+++ b/man/rae.Rd
@@ -5,7 +5,7 @@
 \alias{rae}
 \title{Compute the \eqn{\text{relative}} \eqn{\text{absolute}} \eqn{\text{error}}}
 \usage{
-\method{rae}{numeric}(actual, predicted, w = NULL, ...)
+\method{rae}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 rae(...)
 }
@@ -15,6 +15,8 @@ rae(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/recall.Rd
+++ b/man/recall.Rd
@@ -38,7 +38,7 @@ tpr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/recall.Rd
+++ b/man/recall.Rd
@@ -38,7 +38,7 @@ tpr(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/rmse.Rd
+++ b/man/rmse.Rd
@@ -5,7 +5,7 @@
 \alias{rmse}
 \title{Compute the \eqn{\text{root}} \eqn{\text{mean}} \eqn{\text{squared}} \eqn{\text{error}}}
 \usage{
-\method{rmse}{numeric}(actual, predicted, w = NULL, ...)
+\method{rmse}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 rmse(...)
 }
@@ -15,6 +15,8 @@ rmse(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/rmsle.Rd
+++ b/man/rmsle.Rd
@@ -6,7 +6,7 @@
 \alias{rmsle}
 \title{Compute the \eqn{\text{root}} \eqn{\text{mean}} \eqn{\text{squared}} \eqn{\text{logarithmic}} \eqn{\text{error}}}
 \usage{
-\method{rmsle}{numeric}(actual, predicted, w = NULL, ...)
+\method{rmsle}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 rmsle(...)
 }
@@ -16,6 +16,8 @@ rmsle(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/rrmse.Rd
+++ b/man/rrmse.Rd
@@ -6,7 +6,7 @@
 \alias{rrmse}
 \title{Compute the \eqn{\text{relative}} \eqn{\text{root}} \eqn{\text{mean}} \eqn{\text{squared}}  \eqn{\text{error}}}
 \usage{
-\method{rrmse}{numeric}(actual, predicted, w = NULL, ...)
+\method{rrmse}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 rrmse(...)
 }
@@ -16,6 +16,8 @@ rrmse(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/rsq.Rd
+++ b/man/rsq.Rd
@@ -6,7 +6,7 @@
 \alias{rsq}
 \title{Compute the \eqn{R^2}}
 \usage{
-\method{rsq}{numeric}(actual, predicted, k = 0, ...)
+\method{rsq}{numeric}(actual, predicted, k = 0, na.rm = FALSE, ...)
 
 rsq(...)
 }
@@ -17,6 +17,8 @@ rsq(...)
 
 \item{k}{A <\link{numeric}>-vector of \link{length} 1. 0 by default. If \eqn{k>0}
 the function returns the adjusted \eqn{R^2}.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/smape.Rd
+++ b/man/smape.Rd
@@ -6,7 +6,7 @@
 \alias{smape}
 \title{Compute the \eqn{\text{symmetric}} \eqn{\text{mean}} \eqn{\text{absolute}} \eqn{\text{percentage}} \eqn{\text{error}}}
 \usage{
-\method{smape}{numeric}(actual, predicted, w = NULL, ...)
+\method{smape}{numeric}(actual, predicted, w = NULL, na.rm = FALSE, ...)
 
 smape(...)
 }
@@ -16,6 +16,8 @@ smape(...)
 \item{predicted}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The estimated (continuous) response variable.}
 
 \item{w}{A <\link{numeric}>-vector of \link{length} \eqn{n}. The weight assigned to each observation in the data. See \code{\link[stats:weighted.mean]{stats::weighted.mean()}} for more details.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 }

--- a/man/specificity.Rd
+++ b/man/specificity.Rd
@@ -38,7 +38,7 @@ selectivity(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/specificity.Rd
+++ b/man/specificity.Rd
@@ -38,7 +38,7 @@ selectivity(...)
 \item{micro}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{NULL} by default. If \link{TRUE} it returns the
 micro average across all \eqn{k} classes, if \link{FALSE} it returns the macro average. Otherwise class wise performance evaluation.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{TRUE} by default. If \link{FALSE} \link{NA} values will be disregarded when \code{micro = FALSE}.}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/zerooneloss.Rd
+++ b/man/zerooneloss.Rd
@@ -6,7 +6,7 @@
 \alias{zerooneloss}
 \title{Compute the \eqn{\text{Zero}}-\eqn{\text{One}} \eqn{\text{Loss}}}
 \usage{
-\method{zerooneloss}{factor}(actual, predicted, ...)
+\method{zerooneloss}{factor}(actual, predicted, na.rm = FALSE, ...)
 
 \method{zerooneloss}{cmatrix}(x, ...)
 
@@ -16,6 +16,8 @@ zerooneloss(...)
 \item{actual}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
 
 \item{predicted}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
+
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/man/zerooneloss.Rd
+++ b/man/zerooneloss.Rd
@@ -17,7 +17,7 @@ zerooneloss(...)
 
 \item{predicted}{A <\link{factor}>-vector of \link{length} \eqn{n}, and \eqn{k} levels.}
 
-\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.#'}
+\item{na.rm}{A <\link{logical}>-value of \link{length} \eqn{1}. \link{FALSE} by default. If \link{TRUE} NA values will be removed from the computation.}
 
 \item{...}{Arguments passed into other methods.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -776,29 +776,31 @@ BEGIN_RCPP
 END_RCPP
 }
 // rsq
-double rsq(const NumericVector& actual, const NumericVector& predicted, const double k);
-RcppExport SEXP _SLmetrics_rsq(SEXP actualSEXP, SEXP predictedSEXP, SEXP kSEXP) {
+double rsq(const std::vector<double>& actual, const std::vector<double>& predicted, const double k, bool na_rm);
+RcppExport SEXP _SLmetrics_rsq(SEXP actualSEXP, SEXP predictedSEXP, SEXP kSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const NumericVector& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
     Rcpp::traits::input_parameter< const double >::type k(kSEXP);
-    rcpp_result_gen = Rcpp::wrap(rsq(actual, predicted, k));
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(rsq(actual, predicted, k, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // ccc
-double ccc(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, bool correction, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_ccc(SEXP actualSEXP, SEXP predictedSEXP, SEXP correctionSEXP, SEXP wSEXP) {
+double ccc(const std::vector<double>& actual, const std::vector<double>& predicted, bool correction, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_ccc(SEXP actualSEXP, SEXP predictedSEXP, SEXP correctionSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
     Rcpp::traits::input_parameter< bool >::type correction(correctionSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(ccc(actual, predicted, correction, w));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(ccc(actual, predicted, correction, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -818,95 +820,102 @@ BEGIN_RCPP
 END_RCPP
 }
 // mae
-double mae(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_mae(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double mae(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_mae(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(mae(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(mae(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // mape
-double mape(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_mape(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double mape(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_mape(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(mape(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(mape(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // mpe
-double mpe(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_mpe(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double mpe(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_mpe(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(mpe(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(mpe(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // mse
-double mse(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_mse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double mse(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_mse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(mse(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(mse(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // pinball
-double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, const double& alpha, const bool& deviance, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_pinball(SEXP actualSEXP, SEXP predictedSEXP, SEXP alphaSEXP, SEXP devianceSEXP, SEXP wSEXP) {
+double pinball(const std::vector<double>& actual, const std::vector<double>& predicted, double alpha, const bool& deviance, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_pinball(SEXP actualSEXP, SEXP predictedSEXP, SEXP alphaSEXP, SEXP devianceSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< const double& >::type alpha(alphaSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< double >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< const bool& >::type deviance(devianceSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(pinball(actual, predicted, alpha, deviance, w));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(pinball(actual, predicted, alpha, deviance, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // rae
-double rae(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_rae(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double rae(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_rae(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(rae(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(rae(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // rrmse
-double rrmse(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_rrmse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double rrmse(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_rrmse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(rrmse(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(rrmse(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -939,15 +948,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // smape
-double smape(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_smape(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double smape(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_smape(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(smape(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(smape(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1011,19 +1021,19 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SLmetrics_selectivity_cmatrix", (DL_FUNC) &_SLmetrics_selectivity_cmatrix, 3},
     {"_SLmetrics_zerooneloss", (DL_FUNC) &_SLmetrics_zerooneloss, 3},
     {"_SLmetrics_zerooneloss_cmatrix", (DL_FUNC) &_SLmetrics_zerooneloss_cmatrix, 1},
-    {"_SLmetrics_rsq", (DL_FUNC) &_SLmetrics_rsq, 3},
-    {"_SLmetrics_ccc", (DL_FUNC) &_SLmetrics_ccc, 4},
+    {"_SLmetrics_rsq", (DL_FUNC) &_SLmetrics_rsq, 4},
+    {"_SLmetrics_ccc", (DL_FUNC) &_SLmetrics_ccc, 5},
     {"_SLmetrics_huberloss", (DL_FUNC) &_SLmetrics_huberloss, 5},
-    {"_SLmetrics_mae", (DL_FUNC) &_SLmetrics_mae, 3},
-    {"_SLmetrics_mape", (DL_FUNC) &_SLmetrics_mape, 3},
-    {"_SLmetrics_mpe", (DL_FUNC) &_SLmetrics_mpe, 3},
-    {"_SLmetrics_mse", (DL_FUNC) &_SLmetrics_mse, 3},
-    {"_SLmetrics_pinball", (DL_FUNC) &_SLmetrics_pinball, 5},
-    {"_SLmetrics_rae", (DL_FUNC) &_SLmetrics_rae, 3},
-    {"_SLmetrics_rrmse", (DL_FUNC) &_SLmetrics_rrmse, 3},
+    {"_SLmetrics_mae", (DL_FUNC) &_SLmetrics_mae, 4},
+    {"_SLmetrics_mape", (DL_FUNC) &_SLmetrics_mape, 4},
+    {"_SLmetrics_mpe", (DL_FUNC) &_SLmetrics_mpe, 4},
+    {"_SLmetrics_mse", (DL_FUNC) &_SLmetrics_mse, 4},
+    {"_SLmetrics_pinball", (DL_FUNC) &_SLmetrics_pinball, 6},
+    {"_SLmetrics_rae", (DL_FUNC) &_SLmetrics_rae, 4},
+    {"_SLmetrics_rrmse", (DL_FUNC) &_SLmetrics_rrmse, 4},
     {"_SLmetrics_rmse", (DL_FUNC) &_SLmetrics_rmse, 4},
     {"_SLmetrics_rmsle", (DL_FUNC) &_SLmetrics_rmsle, 4},
-    {"_SLmetrics_smape", (DL_FUNC) &_SLmetrics_smape, 3},
+    {"_SLmetrics_smape", (DL_FUNC) &_SLmetrics_smape, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -12,14 +12,15 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // accuracy
-double accuracy(const NumericVector& actual, const NumericVector& predicted);
-RcppExport SEXP _SLmetrics_accuracy(SEXP actualSEXP, SEXP predictedSEXP) {
+double accuracy(const std::vector<int>& actual, const std::vector<int>& predicted, bool na_rm);
+RcppExport SEXP _SLmetrics_accuracy(SEXP actualSEXP, SEXP predictedSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const NumericVector& >::type predicted(predictedSEXP);
-    rcpp_result_gen = Rcpp::wrap(accuracy(actual, predicted));
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(accuracy(actual, predicted, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -948,7 +949,7 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_SLmetrics_accuracy", (DL_FUNC) &_SLmetrics_accuracy, 2},
+    {"_SLmetrics_accuracy", (DL_FUNC) &_SLmetrics_accuracy, 3},
     {"_SLmetrics_accuracy_cmatrix", (DL_FUNC) &_SLmetrics_accuracy_cmatrix, 1},
     {"_SLmetrics_baccuracy", (DL_FUNC) &_SLmetrics_baccuracy, 3},
     {"_SLmetrics_baccuracy_cmatrix", (DL_FUNC) &_SLmetrics_baccuracy_cmatrix, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -752,14 +752,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // zerooneloss
-double zerooneloss(const NumericVector& actual, const NumericVector& predicted);
-RcppExport SEXP _SLmetrics_zerooneloss(SEXP actualSEXP, SEXP predictedSEXP) {
+double zerooneloss(const std::vector<int>& actual, const std::vector<int>& predicted, bool na_rm);
+RcppExport SEXP _SLmetrics_zerooneloss(SEXP actualSEXP, SEXP predictedSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const NumericVector& >::type predicted(predictedSEXP);
-    rcpp_result_gen = Rcpp::wrap(zerooneloss(actual, predicted));
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(zerooneloss(actual, predicted, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1005,7 +1006,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SLmetrics_tnr_cmatrix", (DL_FUNC) &_SLmetrics_tnr_cmatrix, 3},
     {"_SLmetrics_selectivity", (DL_FUNC) &_SLmetrics_selectivity, 4},
     {"_SLmetrics_selectivity_cmatrix", (DL_FUNC) &_SLmetrics_selectivity_cmatrix, 3},
-    {"_SLmetrics_zerooneloss", (DL_FUNC) &_SLmetrics_zerooneloss, 2},
+    {"_SLmetrics_zerooneloss", (DL_FUNC) &_SLmetrics_zerooneloss, 3},
     {"_SLmetrics_zerooneloss_cmatrix", (DL_FUNC) &_SLmetrics_zerooneloss_cmatrix, 1},
     {"_SLmetrics_rsq", (DL_FUNC) &_SLmetrics_rsq, 3},
     {"_SLmetrics_ccc", (DL_FUNC) &_SLmetrics_ccc, 4},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -803,16 +803,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // huberloss
-double huberloss(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, const double& delta, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_huberloss(SEXP actualSEXP, SEXP predictedSEXP, SEXP deltaSEXP, SEXP wSEXP) {
+double huberloss(const std::vector<double>& actual, const std::vector<double>& predicted, const double& delta, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_huberloss(SEXP actualSEXP, SEXP predictedSEXP, SEXP deltaSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
     Rcpp::traits::input_parameter< const double& >::type delta(deltaSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(huberloss(actual, predicted, delta, w));
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(huberloss(actual, predicted, delta, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -910,28 +911,30 @@ BEGIN_RCPP
 END_RCPP
 }
 // rmse
-double rmse(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_rmse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double rmse(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_rmse(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(rmse(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(rmse(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
 // rmsle
-double rmsle(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w);
-RcppExport SEXP _SLmetrics_rmsle(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP) {
+double rmsle(const std::vector<double>& actual, const std::vector<double>& predicted, Rcpp::Nullable<std::vector<double>> w, bool na_rm);
+RcppExport SEXP _SLmetrics_rmsle(SEXP actualSEXP, SEXP predictedSEXP, SEXP wSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type actual(actualSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::NumericVector& >::type predicted(predictedSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::NumericVector> >::type w(wSEXP);
-    rcpp_result_gen = Rcpp::wrap(rmsle(actual, predicted, w));
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type actual(actualSEXP);
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type predicted(predictedSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Nullable<std::vector<double>> >::type w(wSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(rmsle(actual, predicted, w, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1010,7 +1013,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SLmetrics_zerooneloss_cmatrix", (DL_FUNC) &_SLmetrics_zerooneloss_cmatrix, 1},
     {"_SLmetrics_rsq", (DL_FUNC) &_SLmetrics_rsq, 3},
     {"_SLmetrics_ccc", (DL_FUNC) &_SLmetrics_ccc, 4},
-    {"_SLmetrics_huberloss", (DL_FUNC) &_SLmetrics_huberloss, 4},
+    {"_SLmetrics_huberloss", (DL_FUNC) &_SLmetrics_huberloss, 5},
     {"_SLmetrics_mae", (DL_FUNC) &_SLmetrics_mae, 3},
     {"_SLmetrics_mape", (DL_FUNC) &_SLmetrics_mape, 3},
     {"_SLmetrics_mpe", (DL_FUNC) &_SLmetrics_mpe, 3},
@@ -1018,8 +1021,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SLmetrics_pinball", (DL_FUNC) &_SLmetrics_pinball, 5},
     {"_SLmetrics_rae", (DL_FUNC) &_SLmetrics_rae, 3},
     {"_SLmetrics_rrmse", (DL_FUNC) &_SLmetrics_rrmse, 3},
-    {"_SLmetrics_rmse", (DL_FUNC) &_SLmetrics_rmse, 3},
-    {"_SLmetrics_rmsle", (DL_FUNC) &_SLmetrics_rmsle, 3},
+    {"_SLmetrics_rmse", (DL_FUNC) &_SLmetrics_rmse, 4},
+    {"_SLmetrics_rmsle", (DL_FUNC) &_SLmetrics_rmsle, 4},
     {"_SLmetrics_smape", (DL_FUNC) &_SLmetrics_smape, 3},
     {NULL, NULL, 0}
 };

--- a/src/classification_Accuracy.cpp
+++ b/src/classification_Accuracy.cpp
@@ -8,10 +8,10 @@ using namespace Rcpp;
 //'
 //' @export
 // [[Rcpp::export(accuracy.factor)]]
-double accuracy(const NumericVector& actual, const NumericVector& predicted)
+double accuracy(const std::vector<int>& actual, const std::vector<int>& predicted, bool na_rm = false)
 {
 
-  return _metric_(actual, predicted);
+  return _metric_(actual, predicted, na_rm);
 
 }
 

--- a/src/classification_Accuracy.h
+++ b/src/classification_Accuracy.h
@@ -13,7 +13,6 @@
 #define EIGEN_USE_MKL_ALL
 EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-
 /*
 Updated Accuracy:
   - The function now accounts for missing values.
@@ -186,6 +185,5 @@ inline __attribute__((always_inline)) double _metric_(const Eigen::MatrixXi& x, 
 
 
 }
-
 
 #endif

--- a/src/classification_ZeroOneLoss.cpp
+++ b/src/classification_ZeroOneLoss.cpp
@@ -7,9 +7,9 @@ using namespace Rcpp;
 //' @method zerooneloss factor
 //' @export
 // [[Rcpp::export(zerooneloss.factor)]]
-double zerooneloss(const NumericVector& actual, const NumericVector& predicted) {
+double zerooneloss(const std::vector<int>& actual, const std::vector<int>& predicted, bool na_rm = false) {
 
-  return _metric_(actual, predicted);
+  return _metric_(actual, predicted, na_rm);
 
 }
 

--- a/src/classification_ZeroOneLoss.h
+++ b/src/classification_ZeroOneLoss.h
@@ -1,3 +1,6 @@
+#ifndef classification_ZeroOneLoss_H
+#define classification_ZeroOneLoss_H
+
 /*
  * This header file is for calculating
  * accucracy and balanced accuracy
@@ -5,6 +8,8 @@
 #include "src_Helpers.h"
 #include <RcppEigen.h>
 #include <cmath>
+#include <vector>
+#include <limits>
 #define EIGEN_USE_MKL_ALL
 EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -13,34 +18,43 @@ EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 /*
  * Zero One Loss; factors
  */
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted)
+inline __attribute__((always_inline)) double _metric_(const std::vector<int>& actual, const std::vector<int>& predicted, bool na_rm)
 {
 
-
-
+  // 1) common parameters
+  // for the calculation
   const int n = actual.size();
-
-  const double* actual_ptr = actual.begin();
-  const double* predicted_ptr = predicted.begin();
-
+  const int NA_INTEGER = std::numeric_limits<int>::min();
   int incorrect_count = 0;
-  int i = 0;
-  int limit = n - (n % 4);
+  int valid_count = 0;
 
-  // Unroll loop with quad
-  // whatever it's called
-  for (; i < limit; i += 4) {
-    incorrect_count += (*(actual_ptr++) != *(predicted_ptr++));
-    incorrect_count += (*(actual_ptr++) != *(predicted_ptr++));
-    incorrect_count += (*(actual_ptr++) != *(predicted_ptr++));
-    incorrect_count += (*(actual_ptr++) != *(predicted_ptr++));
+  
+  // 2) loop through the values
+  // using pointers
+  for (int i = 0; i < n; ++i) {
+      const int actual_value = actual[i];
+      const int predicted_value = predicted[i];
+
+      // 2.1) check for non-NA values
+      const bool is_valid = actual_value != NA_INTEGER && predicted_value != NA_INTEGER;
+      valid_count += is_valid;
+
+      // 2.2) increment correct count if valid and equal
+      incorrect_count += is_valid && (actual_value != predicted_value);
   }
 
-  for (; i < n; ++i) {
-    incorrect_count += (*(actual_ptr++) != *(predicted_ptr++));
+  // 3) if there is missing values
+  // return NAN
+  // NOTE: Maybe this more efficient to have inside
+  // the loop and stop it early
+  if (!na_rm && valid_count != n) {
+      return NAN;
   }
 
-  return static_cast<double> (incorrect_count) / n;
+  // 4) return values
+  // if valid_count is above
+  // 0.
+  return valid_count > 0 ? static_cast<double>(incorrect_count) / valid_count : NAN;
 
 
 }
@@ -61,3 +75,5 @@ inline __attribute__((always_inline)) double _metric_(const Eigen::MatrixXi& x)
   return static_cast<double>(N - TP) / N;
 
 }
+
+#endif

--- a/src/regression_CoefficientOfDetermination.cpp
+++ b/src/regression_CoefficientOfDetermination.cpp
@@ -6,9 +6,9 @@ using namespace Rcpp;
 //' @method rsq numeric
 //' @export
 // [[Rcpp::export(rsq.numeric)]]
-double rsq(const NumericVector& actual, const NumericVector& predicted, const double k = 0)
+double rsq(const std::vector<double>& actual, const std::vector<double>& predicted, const double k = 0, bool na_rm = false)
 {
 
-  return _metric_(actual, predicted, k);
+  return _metric_(actual, predicted, k, na_rm);
 
 }

--- a/src/regression_ConcordanceCorrelationCoefficient.cpp
+++ b/src/regression_ConcordanceCorrelationCoefficient.cpp
@@ -6,15 +6,15 @@
 //' @method ccc numeric
 //' @export
 // [[Rcpp::export(ccc.numeric)]]
-double ccc(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted,bool correction = false, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double ccc(const std::vector<double>& actual, const std::vector<double>& predicted,  bool correction = false, Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
   if (w.isNull()) {
 
-    return _metric_(actual, predicted, correction);
+    return _metric_(actual, predicted, correction, na_rm);
 
   }
 
-  return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w), correction);
+  return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), correction,na_rm);
 
 }

--- a/src/regression_ConcordanceCorrelationCoefficient.h
+++ b/src/regression_ConcordanceCorrelationCoefficient.h
@@ -1,134 +1,162 @@
 #ifndef REGRESSION_CONCORDANCECORRELATIONCOEFFICIENT_H
 #define REGRESSION_CONCORDANCECORRELATIONCOEFFICIENT_H
 
-#include <Rcpp.h>
+#include <vector>
 #include <cmath>
-#include <numeric>
-using namespace Rcpp;
+#include <cstddef>
+#include <limits>
 
 // Unweighted Concordance Correlation Coefficient Calculation
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted, bool correction) {
-  const std::size_t n = actual.size();
-  const double* actual_ptr = actual.begin();
-  const double* predicted_ptr = predicted.begin();
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, bool correction = false, bool na_rm = false) {
+    const std::size_t n = actual.size();
+    if (n == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-  // Calculate means
-  double mean_actual = 0.0;
-  double mean_predicted = 0.0;
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
 
-  int i = 0;
-  int limit = n - (n % 4);
+    // Calculate means
+    double mean_actual = 0.0;
+    double mean_predicted = 0.0;
+    std::size_t valid_count = 0;
 
-  for (; i < limit; i += 4) {
-    mean_actual += actual_ptr[i];
-    mean_actual += actual_ptr[i + 1];
-    mean_actual += actual_ptr[i + 2];
-    mean_actual += actual_ptr[i + 3];
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
 
-    mean_predicted += predicted_ptr[i];
-    mean_predicted += predicted_ptr[i + 1];
-    mean_predicted += predicted_ptr[i + 2];
-    mean_predicted += predicted_ptr[i + 3];
-  }
+        if (!std::isnan(actual_value) && !std::isnan(predicted_value)) {
+            mean_actual += actual_value;
+            mean_predicted += predicted_value;
+            ++valid_count;
+        }
+    }
 
-  for (; i < n; ++i) {
-    mean_actual += actual_ptr[i];
-    mean_predicted += predicted_ptr[i];
-  }
+    if (!na_rm && valid_count != n) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-  mean_actual /= n;
-  mean_predicted /= n;
+    if (valid_count == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-  // Calculate variances and covariance
-  double var_actual = 0.0;
-  double var_predicted = 0.0;
-  double covariance = 0.0;
+    mean_actual /= valid_count;
+    mean_predicted /= valid_count;
 
-  i = 0;
-  for (; i < limit; i += 4) {
-    var_actual += (actual_ptr[i] - mean_actual) * (actual_ptr[i] - mean_actual);
-    var_actual += (actual_ptr[i + 1] - mean_actual) * (actual_ptr[i + 1] - mean_actual);
-    var_actual += (actual_ptr[i + 2] - mean_actual) * (actual_ptr[i + 2] - mean_actual);
-    var_actual += (actual_ptr[i + 3] - mean_actual) * (actual_ptr[i + 3] - mean_actual);
+    // Reset pointers
+    actual_ptr = actual.data();
+    predicted_ptr = predicted.data();
 
-    var_predicted += (predicted_ptr[i] - mean_predicted) * (predicted_ptr[i] - mean_predicted);
-    var_predicted += (predicted_ptr[i + 1] - mean_predicted) * (predicted_ptr[i + 1] - mean_predicted);
-    var_predicted += (predicted_ptr[i + 2] - mean_predicted) * (predicted_ptr[i + 2] - mean_predicted);
-    var_predicted += (predicted_ptr[i + 3] - mean_predicted) * (predicted_ptr[i + 3] - mean_predicted);
+    // Calculate variances and covariance
+    double var_actual = 0.0;
+    double var_predicted = 0.0;
+    double covariance = 0.0;
 
-    covariance += (actual_ptr[i] - mean_actual) * (predicted_ptr[i] - mean_predicted);
-    covariance += (actual_ptr[i + 1] - mean_actual) * (predicted_ptr[i + 1] - mean_predicted);
-    covariance += (actual_ptr[i + 2] - mean_actual) * (predicted_ptr[i + 2] - mean_predicted);
-    covariance += (actual_ptr[i + 3] - mean_actual) * (predicted_ptr[i + 3] - mean_predicted);
-  }
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
 
-  for (; i < n; ++i) {
-    var_actual += (actual_ptr[i] - mean_actual) * (actual_ptr[i] - mean_actual);
-    var_predicted += (predicted_ptr[i] - mean_predicted) * (predicted_ptr[i] - mean_predicted);
-    covariance += (actual_ptr[i] - mean_actual) * (predicted_ptr[i] - mean_predicted);
-  }
+        if (!std::isnan(actual_value) && !std::isnan(predicted_value)) {
+            double diff_actual = actual_value - mean_actual;
+            double diff_predicted = predicted_value - mean_predicted;
 
-  var_actual /= n;
-  var_predicted /= n;
-  covariance /= n;
+            var_actual += diff_actual * diff_actual;
+            var_predicted += diff_predicted * diff_predicted;
+            covariance += diff_actual * diff_predicted;
+        }
+    }
 
-  // Apply bias correction if requested
-  if (correction) {
-    var_actual *= (n - 1.0) / n;
-    var_predicted *= (n - 1.0) / n;
-    covariance *= (n - 1.0) / n;
-  }
+    var_actual /= valid_count;
+    var_predicted /= valid_count;
+    covariance /= valid_count;
 
-  // Calculate the Concordance Correlation Coefficient
-  return (2.0 * covariance) / (var_actual + var_predicted + std::pow(mean_actual - mean_predicted, 2));
+    // Apply bias correction if requested
+    if (correction) {
+        var_actual *= (valid_count - 1.0) / valid_count;
+        var_predicted *= (valid_count - 1.0) / valid_count;
+        covariance *= (valid_count - 1.0) / valid_count;
+    }
+
+    // Calculate the Concordance Correlation Coefficient
+    return (2.0 * covariance) / (var_actual + var_predicted + std::pow(mean_actual - mean_predicted, 2));
 }
 
 // Weighted Concordance Correlation Coefficient Calculation
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted, const NumericVector& w, bool correction) {
-  const std::size_t n = actual.size();
-  const double* actual_ptr = actual.begin();
-  const double* predicted_ptr = predicted.begin();
-  const double* w_ptr = w.begin();
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, const std::vector<double>& weights, bool correction = false, bool na_rm = false) {
+    const std::size_t n = actual.size();
+    if (n == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-  double weighted_mean_actual = 0.0;
-  double weighted_mean_predicted = 0.0;
-  double sum_weights = 0.0;
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
+    const double* weight_ptr = weights.data();
 
-  for (std::size_t i = 0; i < n; ++i) {
-    weighted_mean_actual += actual_ptr[i] * w_ptr[i];
-    weighted_mean_predicted += predicted_ptr[i] * w_ptr[i];
-    sum_weights += w_ptr[i];
-  }
+    double weighted_mean_actual = 0.0;
+    double weighted_mean_predicted = 0.0;
+    double sum_weights = 0.0;
 
-  weighted_mean_actual /= sum_weights;
-  weighted_mean_predicted /= sum_weights;
+    for (std::size_t i = 0; i < n; ++i) {
+        double weight = *(weight_ptr++);
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
 
-  double weighted_var_actual = 0.0;
-  double weighted_var_predicted = 0.0;
-  double weighted_covariance = 0.0;
+        if (!std::isnan(actual_value) && !std::isnan(predicted_value) && !std::isnan(weight)) {
+            weighted_mean_actual += actual_value * weight;
+            weighted_mean_predicted += predicted_value * weight;
+            sum_weights += weight;
+        }
+    }
 
-  for (std::size_t i = 0; i < n; ++i) {
-    double diff_actual = actual_ptr[i] - weighted_mean_actual;
-    double diff_predicted = predicted_ptr[i] - weighted_mean_predicted;
+    if (!na_rm && sum_weights == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-    weighted_var_actual += w_ptr[i] * diff_actual * diff_actual;
-    weighted_var_predicted += w_ptr[i] * diff_predicted * diff_predicted;
-    weighted_covariance += w_ptr[i] * diff_actual * diff_predicted;
-  }
+    if (sum_weights == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
 
-  weighted_var_actual /= sum_weights;
-  weighted_var_predicted /= sum_weights;
-  weighted_covariance /= sum_weights;
+    weighted_mean_actual /= sum_weights;
+    weighted_mean_predicted /= sum_weights;
 
-  if (correction) {
-    weighted_var_actual *= (sum_weights - 1.0) / sum_weights;
-    weighted_var_predicted *= (sum_weights - 1.0) / sum_weights;
-    weighted_covariance *= (sum_weights - 1.0) / sum_weights;
-  }
+    // Reset pointers
+    actual_ptr = actual.data();
+    predicted_ptr = predicted.data();
+    weight_ptr = weights.data();
 
-  // Calculate the Weighted Concordance Correlation Coefficient
-  return (2.0 * weighted_covariance) /
-    (weighted_var_actual + weighted_var_predicted + std::pow(weighted_mean_actual - weighted_mean_predicted, 2));
+    // Calculate variances and covariance
+    double weighted_var_actual = 0.0;
+    double weighted_var_predicted = 0.0;
+    double weighted_covariance = 0.0;
+
+    for (std::size_t i = 0; i < n; ++i) {
+        double weight = *(weight_ptr++);
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
+
+        if (!std::isnan(actual_value) && !std::isnan(predicted_value) && !std::isnan(weight)) {
+            double diff_actual = actual_value - weighted_mean_actual;
+            double diff_predicted = predicted_value - weighted_mean_predicted;
+
+            weighted_var_actual += weight * diff_actual * diff_actual;
+            weighted_var_predicted += weight * diff_predicted * diff_predicted;
+            weighted_covariance += weight * diff_actual * diff_predicted;
+        }
+    }
+
+    weighted_var_actual /= sum_weights;
+    weighted_var_predicted /= sum_weights;
+    weighted_covariance /= sum_weights;
+
+    if (correction) {
+        weighted_var_actual *= (sum_weights - 1.0) / sum_weights;
+        weighted_var_predicted *= (sum_weights - 1.0) / sum_weights;
+        weighted_covariance *= (sum_weights - 1.0) / sum_weights;
+    }
+
+    // Calculate the Weighted Concordance Correlation Coefficient
+    return (2.0 * weighted_covariance) /
+        (weighted_var_actual + weighted_var_predicted + std::pow(weighted_mean_actual - weighted_mean_predicted, 2));
 }
 
 #endif //REGRESSION_CONCORDANCECORRELATIONCOEFFICIENT_H

--- a/src/regression_HuberLoss.cpp
+++ b/src/regression_HuberLoss.cpp
@@ -7,15 +7,15 @@ using namespace Rcpp;
 //' @method huberloss numeric
 //' @export
 // [[Rcpp::export(huberloss.numeric)]]
-double huberloss(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, const double& delta = 1.0, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double huberloss(const std::vector<double>& actual, const std::vector<double>& predicted, const double& delta = 1.0, Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
   if (w.isNull()) {
 
-    return _metric_(actual, predicted, delta);
+    return _metric_(actual, predicted, delta, na_rm);
 
   }
 
-  return _metric_(actual, predicted, delta, Rcpp::as<Rcpp::NumericVector>(w));
+  return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), delta, na_rm);
 
 }

--- a/src/regression_MeanAbsoluteError.cpp
+++ b/src/regression_MeanAbsoluteError.cpp
@@ -5,13 +5,13 @@
 //' @method mae numeric
 //' @export
 // [[Rcpp::export(mae.numeric)]]
-double mae(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue) {
+double mae(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false) {
 
   if (w.isNull()) {
 
-    return _metric_(actual, predicted);
+    return _metric_(actual, predicted, na_rm);
 
   }
 
-  return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+  return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 }

--- a/src/regression_MeanAbsolutePercentageError.cpp
+++ b/src/regression_MeanAbsolutePercentageError.cpp
@@ -6,15 +6,15 @@
 //' @method mape numeric
 //' @export
 // [[Rcpp::export(mape.numeric)]]
-double mape(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double mape(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
    if (w.isNull()) {
 
-      return _metric_(actual, predicted);
+      return _metric_(actual, predicted, na_rm);
 
    }
 
-   return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+   return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
 }

--- a/src/regression_MeanPercentageError.cpp
+++ b/src/regression_MeanPercentageError.cpp
@@ -6,15 +6,15 @@
 //' @method mpe numeric
 //' @export
 // [[Rcpp::export(mpe.numeric)]]
-double mpe(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double mpe(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
    if (w.isNull()) {
 
-      return _metric_(actual, predicted);
+      return _metric_(actual, predicted, na_rm);
 
    }
 
-   return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+   return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
 }

--- a/src/regression_MeanSquaredError.cpp
+++ b/src/regression_MeanSquaredError.cpp
@@ -6,17 +6,13 @@ using namespace Rcpp;
 //' @method mse numeric
 //' @export
 // [[Rcpp::export(mse.numeric)]]
-double mse(
-    const Rcpp::NumericVector& actual,
-    const Rcpp::NumericVector& predicted,
-    Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue
-    ) {
+double mse(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false) {
 
   if (w.isNull()) {
 
-    return _metric_(actual, predicted);
+    return _metric_(actual, predicted, na_rm);
 
   }
 
-  return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+  return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 }

--- a/src/regression_PinballLoss.cpp
+++ b/src/regression_PinballLoss.cpp
@@ -2,11 +2,13 @@
 #include "regression_PinballLoss.h"
 using namespace Rcpp;
 
+
+
 //' @rdname pinball
 //' @method pinball numeric
 //' @export
 // [[Rcpp::export(pinball.numeric)]]
-double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, const double& alpha = 0.5, const bool& deviance = false, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double pinball(const std::vector<double>& actual, const std::vector<double>& predicted, double alpha = 0.5, const bool& deviance = false, Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
    /*
@@ -21,7 +23,7 @@ double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& pre
    // 0) variable declarations
    double output = 0.0;
    double quantile = 0.0;
-   Rcpp::NumericVector quantiles;
+   std::vector<double> quantiles;
 
    // 1) Calculate dsq
    if (deviance) {
@@ -29,15 +31,15 @@ double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& pre
       // 1.1) copy the
       // actual vector and
       // calculate the quantiles
-      Rcpp::NumericVector actualCopy = Rcpp::clone(actual);
-      quantiles = _quantile_(actualCopy, alpha);
+      std::vector<double> actualCopy = actual;
+      quantiles = _quantile_(actualCopy, alpha, na_rm);
 
       // 1.2) unweighted deviance
       // with early return
       if (w.isNull()) {
 
-         quantile = _metric_(actual, quantiles, alpha);
-         output   = _metric_(actual, predicted, alpha);
+         quantile = _metric_(actual, quantiles, alpha, na_rm);
+         output   = _metric_(actual, predicted, alpha, na_rm);
 
 
          return 1.0 - output/quantile;
@@ -46,8 +48,8 @@ double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& pre
 
       // 1.3) weighted deviance
       // with ealy return
-      quantile = _metric_(actual, quantiles, Rcpp::as<Rcpp::NumericVector>(w), alpha);
-      output   = _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w), alpha);
+      quantile = _metric_(actual, quantiles, Rcpp::as<std::vector<double>>(w), alpha, na_rm);
+      output   = _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), alpha, na_rm);
 
       return 1.0 - output/quantile;
 
@@ -57,7 +59,7 @@ double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& pre
    // mean pinball score
    if (w.isNull()) {
 
-      output = _metric_(actual, predicted, alpha);
+      output = _metric_(actual, predicted, alpha, na_rm);
 
       return output;
 
@@ -65,7 +67,7 @@ double pinball(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& pre
 
    // 3) weighted
    // mean pinball score
-   output = _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w), alpha);
+   output = _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), alpha, na_rm);
 
    return output;
 

--- a/src/regression_RelativeAbsoluteError.cpp
+++ b/src/regression_RelativeAbsoluteError.cpp
@@ -6,18 +6,15 @@ using namespace Rcpp;
 //' @method rae numeric
 //' @export
 // [[Rcpp::export(rae.numeric)]]
-double rae(
-   const Rcpp::NumericVector& actual,
-   const Rcpp::NumericVector& predicted,
-   Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue
-) {
+double rae(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
+{
 
  if (w.isNull()) {
 
-   return _metric_(actual, predicted);
+   return _metric_(actual, predicted, na_rm);
 
  }
 
- return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+ return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
 }

--- a/src/regression_RelativeRootMeanSquaredError.cpp
+++ b/src/regression_RelativeRootMeanSquaredError.cpp
@@ -6,18 +6,15 @@ using namespace Rcpp;
 //' @method rrmse numeric
 //' @export
 // [[Rcpp::export(rrmse.numeric)]]
-double rrmse(
-   const Rcpp::NumericVector& actual,
-   const Rcpp::NumericVector& predicted,
-   Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue
-) {
+double rrmse(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
+{
 
  if (w.isNull()) {
 
-   return _metric_(actual, predicted);
+   return _metric_(actual, predicted, na_rm);
 
  }
 
- return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+ return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
 }

--- a/src/regression_RootMeanSquaredError.cpp
+++ b/src/regression_RootMeanSquaredError.cpp
@@ -6,18 +6,15 @@ using namespace Rcpp;
 //' @method rmse numeric
 //' @export
 // [[Rcpp::export(rmse.numeric)]]
-double rmse(
-    const Rcpp::NumericVector& actual,
-    const Rcpp::NumericVector& predicted,
-    Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue
-    ) {
-
+double rmse(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false) 
+{
     if (w.isNull()) {
 
-        return _metric_(actual, predicted);
-
+    return _metric_(actual, predicted, na_rm);
+    
     }
+    
+    return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
-    return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
 }
 

--- a/src/regression_RootMeanSquaredError.h
+++ b/src/regression_RootMeanSquaredError.h
@@ -1,83 +1,77 @@
 #ifndef REGRESSION_ROOTMEANSQUAREDERROR_H
 #define REGRESSION_ROOTMEANSQUAREDERROR_H
-#include <Rcpp.h>
+
+#include <vector>
 #include <cmath>
-using namespace Rcpp;
+#include <cstddef>
+#include <limits>
 
 // Unweighted RMSE
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted)
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, bool na_rm = false)
 {
     const std::size_t n = actual.size();
+    const double NA_DOUBLE = std::numeric_limits<double>::quiet_NaN();
 
-    const double* actual_ptr = actual.begin();
-    const double* predicted_ptr = predicted.begin();
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
 
     double output = 0.0;
-    int i = 0;
-    int limit = n - (n % 4);
+    int valid_count = 0;
 
-    for (; i < limit; i += 4) {
-        double diff0 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff1 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff2 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff3 = *(actual_ptr++) - *(predicted_ptr++);
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
 
-        output += diff0 * diff0;
-        output += diff1 * diff1;
-        output += diff2 * diff2;
-        output += diff3 * diff3;
+        bool is_valid = !std::isnan(actual_value) && !std::isnan(predicted_value);
+        valid_count += is_valid;
+
+        if (is_valid) {
+            double diff = actual_value - predicted_value;
+            output += diff * diff;
+        }
     }
 
-    for (; i < n; ++i) {
-        double diff = *(actual_ptr++) - *(predicted_ptr++);
-        output += diff * diff;
+    if (!na_rm && valid_count != n) {
+        return NA_DOUBLE;
     }
 
-    return std::sqrt(output / n);
+    return valid_count > 0 ? std::sqrt(output / valid_count) : NA_DOUBLE;
 }
 
 // Weighted RMSE
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted, const NumericVector& w)
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, const std::vector<double>& weights, bool na_rm = false)
 {
     const std::size_t n = actual.size();
+    const double NA_DOUBLE = std::numeric_limits<double>::quiet_NaN();
 
-    const double* actual_ptr = actual.begin();
-    const double* predicted_ptr = predicted.begin();
-    const double* w_ptr = w.begin();
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
+    const double* weights_ptr = weights.data();
 
     double output = 0.0;
     double weight_sum = 0.0;
-    int i = 0;
-    int limit = n - (n % 4);
+    int valid_count = 0;
 
-    for (; i < limit; i += 4) {
-        double weight0 = *(w_ptr++);
-        double weight1 = *(w_ptr++);
-        double weight2 = *(w_ptr++);
-        double weight3 = *(w_ptr++);
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
+        double weight = *(weights_ptr++);
 
-        double diff0 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff1 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff2 = *(actual_ptr++) - *(predicted_ptr++);
-        double diff3 = *(actual_ptr++) - *(predicted_ptr++);
+        bool is_valid = !std::isnan(actual_value) && !std::isnan(predicted_value) && !std::isnan(weight);
+        valid_count += is_valid;
 
-        output += weight0 * diff0 * diff0;
-        output += weight1 * diff1 * diff1;
-        output += weight2 * diff2 * diff2;
-        output += weight3 * diff3 * diff3;
-
-        weight_sum += weight0 + weight1 + weight2 + weight3;
+        if (is_valid) {
+            double diff = actual_value - predicted_value;
+            output += weight * diff * diff;
+            weight_sum += weight;
+        }
     }
 
-    for (; i < n; ++i) {
-        double weight = *(w_ptr++);
-        double diff = *(actual_ptr++) - *(predicted_ptr++);
-
-        output += weight * diff * diff;
-        weight_sum += weight;
+    if (!na_rm && valid_count != n) {
+        return NA_DOUBLE;
     }
 
-    return std::sqrt(output / weight_sum);
+    return weight_sum > 0 ? std::sqrt(output / weight_sum) : NA_DOUBLE;
 }
 
 #endif //REGRESSION_ROOTMEANSQUAREDERROR_H

--- a/src/regression_RootMeanSquaredLogarithmicError.cpp
+++ b/src/regression_RootMeanSquaredLogarithmicError.cpp
@@ -6,14 +6,14 @@
 //' @method rmsle numeric
 //' @export
 // [[Rcpp::export(rmsle.numeric)]]
-double rmsle(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double rmsle(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
   if (w.isNull()) {
 
-    return _metric_(actual, predicted);
+      return _metric_(actual, predicted, na_rm);
 
   }
 
-  return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
-
+  return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
+  
 }

--- a/src/regression_SymmetricMeanAbsolutePercentageError.cpp
+++ b/src/regression_SymmetricMeanAbsolutePercentageError.cpp
@@ -6,15 +6,15 @@
 //' @method smape numeric
 //' @export
 // [[Rcpp::export(smape.numeric)]]
-double smape(const Rcpp::NumericVector& actual, const Rcpp::NumericVector& predicted, Rcpp::Nullable<Rcpp::NumericVector> w = R_NilValue)
+double smape(const std::vector<double>& actual, const std::vector<double>& predicted,  Rcpp::Nullable<std::vector<double>> w = R_NilValue, bool na_rm = false)
 {
 
    if (w.isNull()) {
 
-      return _metric_(actual, predicted);
+      return _metric_(actual, predicted, na_rm);
 
    }
 
-   return _metric_(actual, predicted, Rcpp::as<Rcpp::NumericVector>(w));
+   return _metric_(actual, predicted, Rcpp::as<std::vector<double>>(w), na_rm);
 
 }

--- a/src/regression_SymmetricMeanAbsolutePercentageError.h
+++ b/src/regression_SymmetricMeanAbsolutePercentageError.h
@@ -1,108 +1,80 @@
 #ifndef REGRESSION_SYMMETRICMEANABSOLUTEPERCENTAGEERROR_H
 #define REGRESSION_SYMMETRICMEANABSOLUTEPERCENTAGEERROR_H
 
-#include <Rcpp.h>
+#include <vector>
 #include <cmath>
-using namespace Rcpp;
+#include <cstddef>
+#include <limits>
 
-// Unweighted SMAPE Calculation
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted) {
-  const std::size_t n = actual.size();
-  double output = 0.0;
+// Unweighted SMAPE
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, bool na_rm = false)
+{
+    const std::size_t n = actual.size();
+    const double NA_DOUBLE = std::numeric_limits<double>::quiet_NaN();
 
-  const double* actual_ptr = actual.begin();
-  const double* predicted_ptr = predicted.begin();
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
 
-  int i = 0;
-  int limit = n - (n % 4);
+    double output = 0.0;
+    int valid_count = 0;
 
-  for (; i < limit; i += 4) {
-    double denominator0 = std::abs(actual_ptr[i]) + std::abs(predicted_ptr[i]);
-    double denominator1 = std::abs(actual_ptr[i + 1]) + std::abs(predicted_ptr[i + 1]);
-    double denominator2 = std::abs(actual_ptr[i + 2]) + std::abs(predicted_ptr[i + 2]);
-    double denominator3 = std::abs(actual_ptr[i + 3]) + std::abs(predicted_ptr[i + 3]);
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
 
-    if (denominator0 != 0) {
-      double difference0 = std::abs(actual_ptr[i] - predicted_ptr[i]) / (denominator0 / 2);
-      output += difference0;
+        bool is_valid = !std::isnan(actual_value) && !std::isnan(predicted_value);
+        valid_count += is_valid;
+
+        if (is_valid) {
+            double denominator = std::abs(actual_value) + std::abs(predicted_value);
+            if (denominator != 0) {
+                double difference = std::abs(actual_value - predicted_value) / (denominator / 2);
+                output += difference;
+            }
+        }
     }
 
-    if (denominator1 != 0) {
-      double difference1 = std::abs(actual_ptr[i + 1] - predicted_ptr[i + 1]) / (denominator1 / 2);
-      output += difference1;
+    if (!na_rm && valid_count != n) {
+        return NA_DOUBLE;
     }
 
-    if (denominator2 != 0) {
-      double difference2 = std::abs(actual_ptr[i + 2] - predicted_ptr[i + 2]) / (denominator2 / 2);
-      output += difference2;
-    }
-
-    if (denominator3 != 0) {
-      double difference3 = std::abs(actual_ptr[i + 3] - predicted_ptr[i + 3]) / (denominator3 / 2);
-      output += difference3;
-    }
-  }
-
-  for (; i < n; ++i) {
-    double denominator = std::abs(actual_ptr[i]) + std::abs(predicted_ptr[i]);
-    if (denominator != 0) {
-      double difference = std::abs(actual_ptr[i] - predicted_ptr[i]) / (denominator / 2);
-      output += difference;
-    }
-  }
-
-  return (output / n);
+    return valid_count > 0 ? (output / valid_count) : NA_DOUBLE;
 }
 
-// Weighted SMAPE Calculation
-inline __attribute__((always_inline)) double _metric_(const NumericVector& actual, const NumericVector& predicted, const NumericVector& w) {
-  const std::size_t n = actual.size();
-  double numerator = 0.0;
-  double denominator = 0.0;
+// Weighted SMAPE
+inline __attribute__((always_inline)) double _metric_(const std::vector<double>& actual, const std::vector<double>& predicted, const std::vector<double>& weights, bool na_rm = false)
+{
+    const std::size_t n = actual.size();
+    const double NA_DOUBLE = std::numeric_limits<double>::quiet_NaN();
 
-  const double* actual_ptr = actual.begin();
-  const double* predicted_ptr = predicted.begin();
-  const double* w_ptr = w.begin();
+    const double* actual_ptr = actual.data();
+    const double* predicted_ptr = predicted.data();
+    const double* weights_ptr = weights.data();
 
-  int i = 0;
-  int limit = n - (n % 4);
+    double numerator = 0.0;
+    double denominator = 0.0;
 
-  for (; i < limit; i += 4) {
-    double total_abs0 = std::abs(actual_ptr[i]) + std::abs(predicted_ptr[i]);
-    double total_abs1 = std::abs(actual_ptr[i + 1]) + std::abs(predicted_ptr[i + 1]);
-    double total_abs2 = std::abs(actual_ptr[i + 2]) + std::abs(predicted_ptr[i + 2]);
-    double total_abs3 = std::abs(actual_ptr[i + 3]) + std::abs(predicted_ptr[i + 3]);
+    for (std::size_t i = 0; i < n; ++i) {
+        double actual_value = *(actual_ptr++);
+        double predicted_value = *(predicted_ptr++);
+        double weight = *(weights_ptr++);
 
-    if (total_abs0 != 0) {
-      numerator += std::abs(actual_ptr[i] - predicted_ptr[i]) / (total_abs0 / 2) * w_ptr[i];
-      denominator += w_ptr[i];
+        bool is_valid = !std::isnan(actual_value) && !std::isnan(predicted_value) && !std::isnan(weight);
+
+        if (is_valid) {
+            double total_abs = std::abs(actual_value) + std::abs(predicted_value);
+            if (total_abs != 0) {
+                numerator += std::abs(actual_value - predicted_value) / (total_abs / 2) * weight;
+                denominator += weight;
+            }
+        }
     }
 
-    if (total_abs1 != 0) {
-      numerator += std::abs(actual_ptr[i + 1] - predicted_ptr[i + 1]) / (total_abs1 / 2) * w_ptr[i + 1];
-      denominator += w_ptr[i + 1];
+    if (!na_rm && denominator == 0) {
+        return NA_DOUBLE;
     }
 
-    if (total_abs2 != 0) {
-      numerator += std::abs(actual_ptr[i + 2] - predicted_ptr[i + 2]) / (total_abs2 / 2) * w_ptr[i + 2];
-      denominator += w_ptr[i + 2];
-    }
-
-    if (total_abs3 != 0) {
-      numerator += std::abs(actual_ptr[i + 3] - predicted_ptr[i + 3]) / (total_abs3 / 2) * w_ptr[i + 3];
-      denominator += w_ptr[i + 3];
-    }
-  }
-
-  for (; i < n; ++i) {
-    double total_abs = std::abs(actual_ptr[i]) + std::abs(predicted_ptr[i]);
-    if (total_abs != 0) {
-      numerator += std::abs(actual_ptr[i] - predicted_ptr[i]) / (total_abs / 2) * w_ptr[i];
-      denominator += w_ptr[i];
-    }
-  }
-
-  return numerator / denominator;
+    return denominator > 0 ? numerator / denominator : NA_DOUBLE;
 }
 
 #endif //REGRESSION_SYMMETRICMEANABSOLUTEPERCENTAGEERROR_H

--- a/tests/testthat/test-regression.R
+++ b/tests/testthat/test-regression.R
@@ -55,7 +55,22 @@ testthat::test_that(
           is.numeric(.f(actual, predicted, w = w)),
           is.numeric(.f(actual, predicted)),
           length(.f(actual, predicted, w = w)) == 1,
-          length(.f(actual, predicted)) == 1
+          length(.f(actual, predicted)) == 1,
+          set_equal(
+            .f(c(actual,NA), c(predicted, NA), w = c(w, NA), na.rm = TRUE),
+            .f(actual, predicted, w = w)
+          ),
+          set_equal(
+            .f(c(actual, NA), c(predicted, NA), na.rm = TRUE),
+            .f(actual, predicted)
+          ),
+          is.na(
+            .f(c(actual, NA), c(predicted, NA), na.rm = FALSE)
+          )
+        ),
+        label = paste(
+          names(sl_function)[i],
+          "Not all true"
         )
       )
 

--- a/tests/testthat/test-rsq.R
+++ b/tests/testthat/test-rsq.R
@@ -9,7 +9,6 @@ testthat::test_that(
   desc = "Test that `rsq()`-function is consistent with the `lm()`-function",
   code = {
 
-
     # 0) run a regression
     # on mtcars
     model <-  lm(
@@ -43,10 +42,22 @@ testthat::test_that(
       )
     )
 
+    # 4) testthat missing
+    # values are handled correctly
 
+    # 4.1) create actual and predicted
+    # with large noise
+    actual    <- rnorm(n = 100)
+    predicted <- actual + rnorm(n = 100, 10, 10)
 
+    # 4.2) test that they are equal
+    testthat::expect_true(
+      set_equal(
+        target  = rsq(actual, predicted), 
+        current = rsq(c(actual, NA), c(predicted, NA),na.rm = TRUE)
+      )
+    )
   }
 )
-
 
 # script end;

--- a/tools/modifyRcppExports.R
+++ b/tools/modifyRcppExports.R
@@ -17,7 +17,7 @@ content <- readLines(file_path)
 # 2) start by modifying
 # the na_rm = TRUE to na.rm = TRUE, ...
 # Replace all occurrences of ') {' with ', ...) {'
-updated_content <- gsub(", na_rm = TRUE\\) \\{", ", na.rm = TRUE, ...) {", content)
+updated_content <- gsub(", na_rm = (TRUE|FALSE)\\) \\{", ", na.rm = \\1) {", content)
 
 # 3) now replace na_rm with na_rm = na.rm
 # to pass the argument
@@ -50,7 +50,7 @@ foo_update <- c(
   # "prROC"
 )
 
-foo_update <- as.vector(outer(foo_update, c("cmatrix", "factor", "numeric", "default"), paste, sep = "."))
+foo_update <- as.vector(outer("[a-z]*", c("cmatrix", "factor", "numeric", "default"), paste, sep = "."))
 
 # 5) Modify the function signatures in RcppExports to append ', ...' to the argument list
 for (fname in foo_update) {


### PR DESCRIPTION
## About

Issue https://github.com/serkor1/SLmetrics/issues/8 concerns non-transparent `NA`-handling in pairwise regression and classification metrics. When developing this package it was intended that `NA`-values were to be handled outside of the functions using wrappers; this was the main idea up until https://github.com/serkor1/SLmetrics/commit/4bd30bd1f6638d6612f4d364009bfd35b8e5aeb4 (See point 5).

Explicit and transparent `NA`-handling is essential for any package. Posting this Issue https://github.com/serkor1/SLmetrics/issues/8 significantly improved the quality of {SLmetrics} - thank you @EmilHvitfeldt.

## Changes

* All pair-wise regression and classification functions now uses `na.rm`-arguments, to explicitly handle `NA`-values.
* All pair-wise regression and classification functions now uses `std::vector` instead of `NumericVector`, it appears to faster (See 'On performance')

## On performance

``` r
rm(list = ls()); gc()
#>          used (Mb) gc trigger (Mb) max used (Mb)
#> Ncells 542439 29.0    1186437 63.4   726777 38.9
#> Vcells 977321  7.5    8388608 64.0  1972559 15.1
Rcpp::sourceCpp(
  "src/classification_Accuracy.cpp"
)

# 1) generate classes
# 1.1) actual classes
actual <- factor(
  sample(
    x       = letters[1:3],
    size    = 2e4,
    replace = TRUE
  )
)

# 1.2) predicted classes
predicted <-  factor(
  sample(
    x       = letters[1:3],
    size    = 2e4,
    replace = TRUE
  )
)

# 2) benchmarrk
microbenchmark::microbenchmark(
  `(without NA-handlins)` = SLmetrics::accuracy(actual, predicted),
  `(With NA handling)`    = accuracy.factor(actual, predicted)
)
#> Unit: microseconds
#>                   expr    min      lq      mean median     uq      max neval
#>  (without NA-handlins) 16.051 16.1670 107.41617 16.446 16.522 5968.758   100
#>     (With NA handling) 15.461 15.5465  15.73808 15.791 15.877   16.770   100
```

<sup>Created on 2024-12-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

> [!NOTE]
>
> This PR **ONLY** addresses the raised issue for `.factor` and `.numeric` methods. The `cmatrix`-method needs 
> significant rework. 
>
> This will be fixed soon (TM)