### PR TITLE
:rocket: OpenMP support for `cmatrix()`

### DIFF
--- a/src/classification_ConfusionMatrix.h
+++ b/src/classification_ConfusionMatrix.h
@@ -1,21 +1,28 @@
 #ifndef CLASSIFICATION_CONFUSION_MATRIX_H
 #define CLASSIFICATION_CONFUSION_MATRIX_H
 
+#include "utilities_Package.h"
 #include <RcppEigen.h>
 #include <cmath>
+
+#ifdef _OPENMP
+    #include <omp.h>
+#endif
+
 #define EIGEN_USE_MKL_ALL
 EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 class ConfusionMatrixClass {
-    protected:
+    private:
         Rcpp::IntegerVector actual_;
         Rcpp::IntegerVector predicted_;
         Rcpp::CharacterVector levels_;
         int k_;
 
+    protected:
         void prepareLevels() {
             levels_ = actual_.attr("levels");
-            k_      = levels_.length() + 1;
+            k_ = levels_.length() + 1;
         }
 
         Rcpp::NumericMatrix finalizeMatrix(const Eigen::MatrixXd& matrix) const {
@@ -26,9 +33,8 @@ class ConfusionMatrixClass {
             return output;
         }
 
-        
         template <typename MatrixType>
-        MatrixType computeMatrix() const {
+        MatrixType computeMatrixSingleThreaded() const {
             MatrixType placeholder = MatrixType::Zero(k_, k_).eval();
             const int n = actual_.size();
 
@@ -36,9 +42,10 @@ class ConfusionMatrixClass {
             const int* predicted_ptr = predicted_.begin();
             auto matrix_ptr = placeholder.data();
 
+            // Unrolled loop for efficiency
             int i = 0;
             for (; i <= n - 6; i += 6) {
-                ++matrix_ptr[predicted_ptr[i] * k_ + actual_ptr[i]];
+                ++matrix_ptr[predicted_ptr[i]     * k_ + actual_ptr[i]    ];
                 ++matrix_ptr[predicted_ptr[i + 1] * k_ + actual_ptr[i + 1]];
                 ++matrix_ptr[predicted_ptr[i + 2] * k_ + actual_ptr[i + 2]];
                 ++matrix_ptr[predicted_ptr[i + 3] * k_ + actual_ptr[i + 3]];
@@ -54,7 +61,7 @@ class ConfusionMatrixClass {
         }
 
         template <typename MatrixType>
-        MatrixType computeMatrix(const Rcpp::NumericVector& weights) const {
+        MatrixType computeMatrixSingleThreaded(const Rcpp::NumericVector& weights) const {
             MatrixType placeholder = MatrixType::Zero(k_, k_).eval();
             const int n = actual_.size();
 
@@ -65,7 +72,7 @@ class ConfusionMatrixClass {
 
             int i = 0;
             for (; i <= n - 6; i += 6) {
-                matrix_ptr[predicted_ptr[i] * k_ + actual_ptr[i]] += weights_ptr[i];
+                matrix_ptr[predicted_ptr[i]     * k_ + actual_ptr[i]    ] += weights_ptr[i];
                 matrix_ptr[predicted_ptr[i + 1] * k_ + actual_ptr[i + 1]] += weights_ptr[i + 1];
                 matrix_ptr[predicted_ptr[i + 2] * k_ + actual_ptr[i + 2]] += weights_ptr[i + 2];
                 matrix_ptr[predicted_ptr[i + 3] * k_ + actual_ptr[i + 3]] += weights_ptr[i + 3];
@@ -78,34 +85,119 @@ class ConfusionMatrixClass {
             }
 
             return placeholder.block(1, 1, k_ - 1, k_ - 1);
+
+        }
+
+        template <typename MatrixType>
+        MatrixType computeMatrixParallel() const {
+            const int n = actual_.size();
+            const int* actual_ptr = actual_.begin();
+            const int* predicted_ptr = predicted_.begin();
+
+            MatrixType globalMatrix = MatrixType::Zero(k_, k_);
+
+            #ifdef _OPENMP
+            #pragma omp parallel if(getUseOpenMP()) 
+            {
+                MatrixType localMatrix = MatrixType::Zero(k_, k_);
+                auto local_ptr = localMatrix.data();
+
+                #pragma omp for schedule(static)
+                for (int i = 0; i < n; i++) {
+                    ++local_ptr[predicted_ptr[i] * k_ + actual_ptr[i]];
+                }
+
+                // Reduction
+                #pragma omp critical
+                {
+                    globalMatrix += localMatrix;
+                }
+            }
+            #else
+            
+            globalMatrix = computeMatrixSingleThreaded<MatrixType>();
+            #endif
+
+            return globalMatrix.block(1, 1, k_ - 1, k_ - 1);
+        }
+
+        template <typename MatrixType>
+        MatrixType computeMatrixParallel(const Rcpp::NumericVector& weights) const {
+            const int n = actual_.size();
+            const int* actual_ptr = actual_.begin();
+            const int* predicted_ptr = predicted_.begin();
+            const double* weights_ptr = weights.begin();
+
+            MatrixType globalMatrix = MatrixType::Zero(k_, k_);
+
+            #ifdef _OPENMP
+            #pragma omp parallel if(getUseOpenMP())
+            {
+                MatrixType localMatrix = MatrixType::Zero(k_, k_);
+                auto local_ptr = localMatrix.data();
+
+                #pragma omp for schedule(static)
+                for (int i = 0; i < n; i++) {
+                    local_ptr[predicted_ptr[i] * k_ + actual_ptr[i]] += weights_ptr[i];
+                }
+
+                #pragma omp critical
+                {
+                    globalMatrix += localMatrix;
+                }
+            }
+            #else
+            globalMatrix = computeMatrixSingleThreaded<MatrixType>(weights);
+            #endif
+
+            return globalMatrix.block(1, 1, k_ - 1, k_ - 1);
         }
 
     public:
 
-        ConfusionMatrixClass(const Rcpp::IntegerVector& actual, const Rcpp::IntegerVector& predicted)
-            : actual_(actual), predicted_(predicted) {
-            prepareLevels();}
+        ConfusionMatrixClass(const Rcpp::IntegerVector& actual,
+                            const Rcpp::IntegerVector& predicted)
+            : actual_(actual), predicted_(predicted)
+        {
+            prepareLevels();
+        }
 
-        /*
-            InputMatrix: An Eigen::MatrixXd passed internally to other classification functions
-            constructMatrix: A Rcpp::NumericMatrix passed directly to R
-        */
-
-        // Unweighted Confusion Matrices
         Eigen::MatrixXd InputMatrix() const {
-            return computeMatrix<Eigen::MatrixXd>();}
+            if (getUseOpenMP()) {
+            #ifdef _OPENMP
+                return computeMatrixParallel<Eigen::MatrixXd>();
+            #else
+                return computeMatrixSingleThreaded<Eigen::MatrixXd>();
+            #endif
+            } else {
+                return computeMatrixSingleThreaded<Eigen::MatrixXd>();
+            }
+        }
 
         Rcpp::NumericMatrix constructMatrix() const {
-            Eigen::MatrixXd matrix = computeMatrix<Eigen::MatrixXd>();
-            return finalizeMatrix(matrix);}
+            Eigen::MatrixXd matrix = InputMatrix();
+            return finalizeMatrix(matrix);
+        }
 
-        // Weighted Confusion Matrices
+        //------------------------------------------------------------------------------
+        // Weighted
+        //------------------------------------------------------------------------------
         Eigen::MatrixXd InputMatrix(const Rcpp::NumericVector& weights) const {
-            return computeMatrix<Eigen::MatrixXd>(weights);}
-        
+            if (getUseOpenMP()) {
+            #ifdef _OPENMP
+                return computeMatrixParallel<Eigen::MatrixXd>(weights);
+            #else
+                return computeMatrixSingleThreaded<Eigen::MatrixXd>(weights);
+            #endif
+            } else {
+                return computeMatrixSingleThreaded<Eigen::MatrixXd>(weights);
+            }
+        }
+
         Rcpp::NumericMatrix constructMatrix(const Rcpp::NumericVector& weights) const {
-            Eigen::MatrixXd matrix = computeMatrix<Eigen::MatrixXd>(weights);
-            return finalizeMatrix(matrix);}
+            Eigen::MatrixXd matrix = InputMatrix(weights);
+            return finalizeMatrix(matrix);
+        }
 };
 
 #endif

--- a/tests/testthat/test-ConfusionMatrix.R
+++ b/tests/testthat/test-ConfusionMatrix.R
@@ -7,88 +7,98 @@ testthat::test_that(
 
     # 2) test that the are 
     # equal to target values
-    for (balanced in c(TRUE, FALSE)) {
+    for (OpenMP in c(TRUE, FALSE)) {
 
-      # 2.1) generate class
-      # values and weights
-      actual    <- create_factor(balanced = balanced)
-      predicted <- create_factor(balanced = balanced)
-      w         <- runif(n = length(actual))
+      # 2.1) enable/disable
+      # OpenMP
+      setUseOpenMP(OpenMP)
 
-      for (weighted in c(TRUE, FALSE)) {
+      for (balanced in c(TRUE, FALSE)) {
 
-        # 2.2) generate sensible 
-        # label information
-        info <- paste(
-          "Balanced = ", balanced,
-          "Weighted = ", weighted
-        )
-
-        # 2.3) generate confusion
-        # matrix
-        if (weighted) {
-
-          confusion_matrix <- weighted.cmatrix(
+        # 2.1) generate class
+        # values and weights
+        actual    <- create_factor(balanced = balanced)
+        predicted <- create_factor(balanced = balanced)
+        w         <- runif(n = length(actual))
+  
+        for (weighted in c(TRUE, FALSE)) {
+  
+          # 2.2) generate sensible 
+          # label information
+          info <- paste(
+            "Balanced = ", balanced,
+            "Weighted = ", weighted,
+            "OpenMP   = ", OpenMP 
+          )
+  
+          # 2.3) generate confusion
+          # matrix
+          if (weighted) {
+  
+            confusion_matrix <- weighted.cmatrix(
+              actual    = actual,
+              predicted = predicted,
+              w         = w
+            )
+            
+          } else {
+  
+            confusion_matrix <- cmatrix(
+              actual    = actual,
+              predicted = predicted
+            )
+  
+          }
+          
+  
+          # 2.3) test that the values
+          # are sensible
+          testthat::expect_true(dim(confusion_matrix)[1] == dim(confusion_matrix)[2], info = info)
+          testthat::expect_true(dim(confusion_matrix)[1] == length(levels(actual)), info = info)
+  
+          # 2.4) test that the values
+          # are equal to target
+          py_confusion_matrix <- py_cmatrix(
             actual    = actual,
             predicted = predicted,
-            w         = w
+            w         = if (weighted) w else NULL 
           )
-          
-        } else {
-
-          confusion_matrix <- cmatrix(
-            actual    = actual,
-            predicted = predicted
-          )
-
-        }
-        
-
-        # 2.3) test that the values
-        # are sensible
-        testthat::expect_true(dim(confusion_matrix)[1] == dim(confusion_matrix)[2], info = info)
-        testthat::expect_true(dim(confusion_matrix)[1] == length(levels(actual)), info = info)
-
-        # 2.4) test that the values
-        # are equal to target
-        py_confusion_matrix <- py_cmatrix(
-          actual    = actual,
-          predicted = predicted,
-          w         = if (weighted) w else NULL 
-        )
-
-        # 2.5) test for equality
-        testthat::expect_true(
-          object = set_equal(
-            current = as.numeric(confusion_matrix),
-            target  = as.numeric(py_confusion_matrix)
-          ),
-          info = info
-        )
-
-        # 2.6) test that
-        # methods works
-
-        # 2.6.1) print method
-        testthat::expect_no_condition(
-          object = invisible(SLmetrics:::print.cmatrix(confusion_matrix))
-        )
-
-        # 2.6.2) summary method
-        testthat::expect_no_condition(
-          object = invisible(SLmetrics:::summary.cmatrix(confusion_matrix))
-        )
-
-        # 2.6.3) plot method
-        testthat::expect_no_condition(
-          object = invisible(SLmetrics:::plot.cmatrix(confusion_matrix))
-        )
-
-
-
-      }
   
+          # 2.5) test for equality
+          testthat::expect_true(
+            object = set_equal(
+              current = as.numeric(confusion_matrix),
+              target  = as.numeric(py_confusion_matrix)
+            ),
+            info = info
+          )
+  
+          # 2.6) test that
+          # methods works
+  
+          # 2.6.1) print method
+          testthat::expect_no_condition(
+            object = invisible(SLmetrics:::print.cmatrix(confusion_matrix))
+          )
+  
+          # 2.6.2) summary method
+          testthat::expect_no_condition(
+            object = invisible(SLmetrics:::summary.cmatrix(confusion_matrix))
+          )
+  
+          # 2.6.3) plot method
+          testthat::expect_no_condition(
+            object = invisible(SLmetrics:::plot.cmatrix(confusion_matrix))
+          )
+  
+  
+  
+        }
+    
+      }
+
     }
+
   }
 )
 


### PR DESCRIPTION
## :books: What?

* **OpenMP support for confusion matrix:** The `cmatrix()` now supports OpenMP. As *most* classification functions uses `cmatrix()` in the backend, the OpenMP is now supported for most classification functions.

## :eyes: Showcase

``` r
# 1) set seed
rm(list = ls()); invisible(gc());

# 2) define values
# for classes
set.seed(1903)
actual <- factor(sample(letters[1:3], 1e7, TRUE))
predicted <- factor(sample(letters[1:3], 1e7, TRUE))

# 3) benchmark with OpenMP
SLmetrics::setUseOpenMP(TRUE)
#> OpenMP usage set to: enabled

bench::mark(
  `{With OpenMP}`  = SLmetrics::cmatrix(actual, predicted)
)
#> # A tibble: 1 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 {With OpenMP}    556µs    587µs     1463.    2.51KB     2.00

# 4) benchmark without OpenMP
SLmetrics::setUseOpenMP(FALSE)
#> OpenMP usage set to: disabled

bench::mark(
  `{Without OpenMP}`  = SLmetrics::cmatrix(actual, predicted)
)
#> # A tibble: 1 × 6
#>   expression            min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>       <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 {Without OpenMP}   6.02ms   6.07ms      165.        0B        0
```

<sup>Created on 2025-01-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>