### PR TITLE
:hammer: Concurrency

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,8 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [development]
-    paths: ['.github/workflows/R-CMD-check.yaml']
+      branches-ignore:
+      - stable
+      - main
   pull_request:
     branches: [development]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [development]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: R-CMD-check
 
 permissions: read-all

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -6,6 +6,10 @@ on:
       - stable
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: Build Docs
 
 jobs:

--- a/.github/workflows/macos-check-clang.yaml
+++ b/.github/workflows/macos-check-clang.yaml
@@ -2,8 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [development]
-    paths: ['.github/workflows/macos-check-clang.yaml']
+      branches-ignore:
+      - stable
+      - main
   pull_request:
     branches: [development]
 

--- a/.github/workflows/macos-check-clang.yaml
+++ b/.github/workflows/macos-check-clang.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [development]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: macOS-clang
 
 permissions: read-all

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [development]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: test-coverage.yaml
 
 permissions: read-all

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,8 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [development]
-    paths: ['.github/workflows/test-coverage.yaml']
+      branches-ignore:
+      - stable
+      - main
   pull_request:
     branches: [development]
 


### PR DESCRIPTION
## :books: What?

* If there is concurrent pushes on same ref, branch or PR the currently running actions will be cancelled.
* **All** workflows will be triggered on any branch except *main* or *stable*. This was disabled on experimental branches due to multiple pushes, but with the new controls it should be more smooth now.