### PR TITLE
:books: Online documentation

### DIFF
--- a/docs/benchmark.qmd
+++ b/docs/benchmark.qmd
@@ -178,7 +178,7 @@ benchmark <- function(
 ```{r}
 #| code-fold: true
 #| label: tbl-regression
-#| tbl-cap: Benchmarking selected regression metrics
+#| tbl-cap: Benchmarks of Root Mean Squared Error (RMSE), Pinball Loss and Huber Loss. Each benchmark is run 10 times with two input vectors of 10 million elements.
 benchmark(
     `{RMSE}`  = SLmetrics::rmse(num_actual, num_predicted),
     `{Pinball Loss}` = SLmetrics::pinball(num_actual, num_predicted),
@@ -190,7 +190,7 @@ benchmark(
 ```{r}
 #| code-fold: true
 #| label: tbl-regression-comparison
-#| tbl-cap: Benchmarking RMSE across \{pkgs\}
+#| tbl-cap: Benchmarking Root Mean Squared Error (RMSE) across `{pkgs}`. Each benchmark is run 10 times with two input vectors of 10 million elements.
 benchmark(
     `{SLmetrics}` = SLmetrics::rmse(num_actual, num_predicted),
     `{MLmetrics}` = MLmetrics::RMSE(num_actual, num_predicted),
@@ -205,7 +205,7 @@ benchmark(
 ```{r}
 #| code-fold: true
 #| label: tbl-classification
-#| tbl-cap: Benchmarking selected classification metrics
+#| tbl-cap: Benchmarks of the Confusion Matrix, Accuracy, and F-Beta score. Each benchmark is run 10 times with two input vectors of 10 million elements.
 benchmark(
     `{Confusion Matrix}`  = SLmetrics::cmatrix(fct_actual, fct_predicted),
     `{Accuracy}` = SLmetrics::accuracy(fct_actual, fct_predicted),
@@ -217,7 +217,7 @@ benchmark(
 ```{r}
 #| code-fold: true
 #| label: tbl-classification-comparison
-#| tbl-cap: Benchmarking a 3x3 confusion matrix across \{pkgs\}
+#| tbl-cap: Benchmarking a 3×3 confusion matrix across `{pkgs}`. Each benchmark is run 10 times with two input vectors of 10 million elements and three classes.
 benchmark(
     `{SLmetrics}`    = SLmetrics::cmatrix(fct_actual, fct_predicted),
     `{MLmetrics}`    = MLmetrics::ConfusionMatrix(fct_predicted, fct_actual),

--- a/docs/garbage.qmd
+++ b/docs/garbage.qmd
@@ -125,9 +125,9 @@ predicted <- rev(actual)
 
 # 2) evaluate with RMSLE
 try(
-    RMSLE(
-    actual,
-    predicted
+    SLmetrics::RMSLE(
+        actual,
+        predicted
     )
 )
 ``` 

--- a/docs/openmp.qmd
+++ b/docs/openmp.qmd
@@ -28,19 +28,29 @@ And disabled as follows:
 SLmetrics::openmp.off()
 ```
 
-By `default` all cores are used. To control the amount of cores, see the following code:
+By `default` all threads are used. To control the amount of threads, see the following code:
 
 ```{r}
 SLmetrics::openmp.threads(3)
 ```
 
-To use all cores:
+To use all threads:
 
 ```{r}
 SLmetrics::openmp.threads(NULL)
 ```
 
+## Available threads
+
+The number of available threads are detected automatically, but can also be viewed using `SLmetrics::openmp.threads()` without passsing any arguments. See below:
+
+```{r}
+SLmetrics::openmp.threads()
+```
+
 ## Benchmarking OpenMP
+
+To benchmark the performance gain on enabling OpenMP, the same setup as in @sec-benchmarking is used. Below is the `actual` and `predicted` values are generated.
 
 ```{r}
 #| include: false
@@ -98,6 +108,7 @@ benchmark <- function(
 
 ```{r}
 #| include: false
+#| message: false
 #| echo: false
 # classification function
 create_factor <- function(
@@ -147,7 +158,9 @@ fct_predicted <- create_factor()
 
 ```{r}
 #| code-fold: true
-#| messages: false
+#| message: false
+#| label: tbl-classification-openmp
+#| tbl-cap: Benchmark of computing a 3x3 confusion matrix with OpenMP enabled. Each benchmark is run 10 times with two input vectors of 10 million elements.
 SLmetrics::openmp.on()
 
 benchmark(
@@ -158,10 +171,16 @@ benchmark(
 
 ```{r}
 #| code-fold: true
-#| messages: false
+#| message: false
+#| label: tbl-classification
+#| tbl-cap: Benchmark of computing a 3x3 confusion matrix with OpenMP enabled. Each benchmark is run 10 times with two input vectors of 10 million elements.
 SLmetrics::openmp.off()
 
 benchmark(
     `Wihtout OpenMP` = SLmetrics::cmatrix(fct_actual, fct_predicted)
 )
 ```
+
+## Key take-aways
+
+Enabling OpenMP support can decrease computation time significantly - but it should *only* be used conciously, and with care, to avoid function calls competing for the same threads. This is especially the case if you are running a, say, neural network in parallel.

--- a/docs/openmp.qmd
+++ b/docs/openmp.qmd
@@ -42,7 +42,7 @@ SLmetrics::openmp.threads(NULL)
 
 ## Available threads
 
-The number of available threads are detected automatically, but can also be viewed using `SLmetrics::openmp.threads()` without passsing any arguments. See below:
+The number of available threads are detected automatically, but can also be viewed using `SLmetrics::openmp.threads()` without passing any arguments. See below:
 
 ```{r}
 SLmetrics::openmp.threads()
@@ -183,4 +183,4 @@ benchmark(
 
 ## Key take-aways
 
-Enabling OpenMP support can decrease computation time significantly - but it should *only* be used conciously, and with care, to avoid function calls competing for the same threads. This is especially the case if you are running a, say, neural network in parallel.
+Enabling OpenMP support can decrease computation time significantly - but it should *only* be used consciously, and with care, to avoid function calls competing for the same threads. This is especially the case if you are running a, say, neural network in parallel.

--- a/docs/summary.qmd
+++ b/docs/summary.qmd
@@ -2,7 +2,7 @@
 
 ## Basic Usage
 
-Computing performance metrics with [{SLmetrics}](https://github.com/serkor1/SLmetrics) is straightforward. At its most basic level, [{SLmetrics}](https://github.com/serkor1/SLmetrics) accepts vectors of <[factor]> or <[numeric]> values as input. Here are two examples demonstrating its basic usage.
+Computing performance metrics with [{SLmetrics}](https://github.com/serkor1/SLmetrics) is straightforward. At its most basic level, [{SLmetrics}](https://github.com/serkor1/SLmetrics) accepts vectors of `<factor>` or `<numeric>` values as input. Here are two examples demonstrating its basic usage.
 
 ### Classification metrics
 

--- a/docs/summary.qmd
+++ b/docs/summary.qmd
@@ -2,6 +2,42 @@
 
 ## Basic Usage
 
+Computing performance metrics with [{SLmetrics}](https://github.com/serkor1/SLmetrics) is straightforward. At its most basic level, [{SLmetrics}](https://github.com/serkor1/SLmetrics) accepts vectors of <[factor]> or <[numeric]> values as input. Here are two examples demonstrating its basic usage.
+
+### Classification metrics
+
+```{r}
+## 1) actual and predicted
+## classes
+fct_actual <- factor(c("A", "A", "B"))
+fct_predicted <- factor(c("B", "A", "B"))
+
+## 2) confusion matrix
+confusion_matrix <- SLmetrics::cmatrix(
+    actual    = fct_actual, 
+    predicted = fct_predicted
+)
+
+## 3) summarize confusion
+## matrix
+summary(confusion_matrix)
+```
+
+### Regression metrics
+
+```{r}
+## 1) actual and predicted
+## values
+num_actual    <- c(10.2, 12.5, 14.1)
+num_predicted <- c(9.8, 11.5, 14.2)
+
+## 2) RMSE
+SLmetrics::rmse(
+    actual    = num_actual,
+    predicted = num_predicted
+)
+```
+
 ## Installation
 
 ### Stable version


### PR DESCRIPTION
## :books: What?

This PR introduces the following changes to the online documentation:

* **Section on basic usage:** The basic usage section now has more elaborated examples.
* **Table captions:** The table captions have been expanded and can now be read independently from the main text.
* **Section on OpenMP:** The section now includes key take-aways and a guide on how to retrieve the number of threads. The section are updated with the new OpenMP api in {SLmetrics}.
* **Minor changes:** Minor layout changes and bug-fixes.