### PR TITLE
:hammer: Skipped unit-tests on CRAN

### DIFF
--- a/tests/testthat/test-Accuracy.R
+++ b/tests/testthat/test-Accuracy.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `accuracy()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_accuracy <- function(

--- a/tests/testthat/test-BalancedAccuracy.R
+++ b/tests/testthat/test-BalancedAccuracy.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `baccuracy()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_baccuracy <- function(

--- a/tests/testthat/test-CoefficientOfDetermination.R
+++ b/tests/testthat/test-CoefficientOfDetermination.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rsq()` function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Coefficient Of Determination
     # wrapper
     wrapped_rsq <- function(

--- a/tests/testthat/test-CohensKappa.R
+++ b/tests/testthat/test-CohensKappa.R
@@ -4,6 +4,8 @@
 testthat::test_that(
   desc = "Test `ckappa()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_ckappa <- function(

--- a/tests/testthat/test-ConcordanceCorrelationCoefficient.R
+++ b/tests/testthat/test-ConcordanceCorrelationCoefficient.R
@@ -4,6 +4,8 @@
 testthat::test_that(
   desc = "Test `ccc()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_ccc <- function(

--- a/tests/testthat/test-ConfusionMatrix.R
+++ b/tests/testthat/test-ConfusionMatrix.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `cmatrix()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 2) test that the are 
     # equal to target values
     for (OpenMP in c(TRUE, FALSE)) {

--- a/tests/testthat/test-CrossEntropy.R
+++ b/tests/testthat/test-CrossEntropy.R
@@ -4,6 +4,8 @@
 
 testthat::test_that(desc = "Test `cross.entropy()`-function", code ={
 
+  testthat::skip_on_cran()
+
   # 0) matrix generator
   # for the tests
   rand.sum <- function(n){

--- a/tests/testthat/test-Entropy.R
+++ b/tests/testthat/test-Entropy.R
@@ -4,6 +4,8 @@
 
 testthat::test_that(desc = "Test `entropy()`-function", code ={
 
+  testthat::skip_on_cran()
+
   # 0) matrix generator
   # for the tests
   rand.sum <- function(n){

--- a/tests/testthat/test-FBetaScore.R
+++ b/tests/testthat/test-FBetaScore.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `fbeta()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_fbeta <- function(

--- a/tests/testthat/test-FalseDiscoveryRate.R
+++ b/tests/testthat/test-FalseDiscoveryRate.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `fdr()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_fdr <- function(

--- a/tests/testthat/test-FalseOmissionRate.R
+++ b/tests/testthat/test-FalseOmissionRate.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `fer()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_fer <- function(

--- a/tests/testthat/test-FalsePositiveRate.R
+++ b/tests/testthat/test-FalsePositiveRate.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `fpr()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_fpr <- function(

--- a/tests/testthat/test-FowlkesMallowsIndex.R
+++ b/tests/testthat/test-FowlkesMallowsIndex.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `fmi()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct fmi
     # wrapper
     wrapped_fmi <- function(

--- a/tests/testthat/test-HuberLoss.R
+++ b/tests/testthat/test-HuberLoss.R
@@ -4,6 +4,8 @@
 testthat::test_that(
   desc = "Test `huberloss()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_huberloss <- function(

--- a/tests/testthat/test-JaccardIndex.R
+++ b/tests/testthat/test-JaccardIndex.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `jaccard()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_jaccard <- function(

--- a/tests/testthat/test-LogLoss.R
+++ b/tests/testthat/test-LogLoss.R
@@ -3,6 +3,8 @@
 # target functions.
 
 testthat::test_that(desc = "Test `entropy()`-function", code = {
+
+  testthat::skip_on_cran()
   
   wrapped_logloss <- function(
     actual, 

--- a/tests/testthat/test-MattewsCorrerlationCoefficient.R
+++ b/tests/testthat/test-MattewsCorrerlationCoefficient.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `mcc()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct mcc
     # wrapper
     wrapped_mcc <- function(

--- a/tests/testthat/test-MeanAbsoluteError.R
+++ b/tests/testthat/test-MeanAbsoluteError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `mae()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct mae-wrapperr
     wrapped_mae <- function(
       actual,

--- a/tests/testthat/test-MeanAbsolutePercentageError.R
+++ b/tests/testthat/test-MeanAbsolutePercentageError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `mape()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct mape-wrapperr
     wrapped_mape <- function(
       actual,

--- a/tests/testthat/test-MeanPercentageError.R
+++ b/tests/testthat/test-MeanPercentageError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `mpe()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct mpe-wrapperr
     wrapped_mpe <- function(
       actual,

--- a/tests/testthat/test-MeanSquaredError.R
+++ b/tests/testthat/test-MeanSquaredError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `mse()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct mse-wrapperr
     wrapped_mse <- function(
       actual,

--- a/tests/testthat/test-NegativePredictiveValue.R
+++ b/tests/testthat/test-NegativePredictiveValue.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `npv()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_npv <- function(

--- a/tests/testthat/test-PinballLoss.R
+++ b/tests/testthat/test-PinballLoss.R
@@ -4,6 +4,8 @@
 testthat::test_that(
   desc = "Test `pinball()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_pinball <- function(

--- a/tests/testthat/test-Precision.R
+++ b/tests/testthat/test-Precision.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `precision()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_precision <- function(

--- a/tests/testthat/test-ROC.R
+++ b/tests/testthat/test-ROC.R
@@ -6,8 +6,9 @@
 # script start;
 
 testthat::test_that(
-  desc = "Test that `ROC()`-function works as expected",
-  code = {
+  desc = "Test that `ROC()`-function works as expected", code = {
+
+    testthat::skip_on_cran()
 
      # 0) construct ROC
     # wrapper

--- a/tests/testthat/test-Recall.R
+++ b/tests/testthat/test-Recall.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `recall()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_recall <- function(

--- a/tests/testthat/test-RelativeAbsoluteError.R
+++ b/tests/testthat/test-RelativeAbsoluteError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rae()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct rae-wrapperr
     wrapped_rae <- function(
       actual,

--- a/tests/testthat/test-RelativeEntropy.R
+++ b/tests/testthat/test-RelativeEntropy.R
@@ -4,6 +4,8 @@
 
 testthat::test_that(desc = "Test `relative.entropy()`-function", code ={
 
+  testthat::skip_on_cran()
+
   # 0) matrix generator
   # for the tests
   rand.sum <- function(n){

--- a/tests/testthat/test-RelativeRootMeanSquaredError.R
+++ b/tests/testthat/test-RelativeRootMeanSquaredError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rmse()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct rmse-wrapperr
     wrapped_rrmse <- function(
       actual,

--- a/tests/testthat/test-RootMeanSquaredError.R
+++ b/tests/testthat/test-RootMeanSquaredError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rmse()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct rmse-wrapperr
     wrapped_rmse <- function(
       actual,

--- a/tests/testthat/test-RootMeanSquaredLogarithmicError.R
+++ b/tests/testthat/test-RootMeanSquaredLogarithmicError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rmsle()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct rmsle-wrapperr
     wrapped_rmsle <- function(
       actual,

--- a/tests/testthat/test-RootRelativeSquaredError.R
+++ b/tests/testthat/test-RootRelativeSquaredError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `rrse()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct rrse-wrapperr
     wrapped_rrse <- function(
       actual,

--- a/tests/testthat/test-S3-classification.R
+++ b/tests/testthat/test-S3-classification.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test that S3 methods returns the same values for classification metrics (balanced)", code = {
 
+    testthat::skip_on_cran()
+
     # 1) generate class
     # values
     actual    <- create_factor(balanced = TRUE)
@@ -115,6 +117,8 @@ testthat::test_that(
 
 testthat::test_that(
   desc = "Test that S3 methods returns the same values for classification metrics (imbalanced)", code = {
+
+    testthat::skip_on_cran()
 
     # 1) generate class
     # values

--- a/tests/testthat/test-Specificity.R
+++ b/tests/testthat/test-Specificity.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `specificity()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct Balanced Accuracy
     # wrapper
     wrapped_specificity <- function(

--- a/tests/testthat/test-SymmetricMeanAbsoluteError.R
+++ b/tests/testthat/test-SymmetricMeanAbsoluteError.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `smape()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct smape-wrapperr
     wrapped_smape <- function(
       actual,

--- a/tests/testthat/test-ZeroOneLoss.R
+++ b/tests/testthat/test-ZeroOneLoss.R
@@ -5,6 +5,8 @@
 testthat::test_that(
   desc = "Test `zerooneloss()`-function", code = {
 
+    testthat::skip_on_cran()
+
     # 0) construct zerooneloss
     # wrapper
     wrapped_zerooneloss <- function(

--- a/tests/testthat/test-prROC.R
+++ b/tests/testthat/test-prROC.R
@@ -6,8 +6,9 @@
 # script start;
 
 testthat::test_that(
-  desc = "Test that `prROC()`-function works as expected",
-  code = {
+  desc = "Test that `prROC()`-function works as expected", code = {
+
+    testthat::skip_on_cran()
 
     # 0) construct ROC
     # wrapper


### PR DESCRIPTION
## :books: What?

When running `devtools::check_win_devel()` unit-tests fails with reference to missing Python modules. There are currently above 600 unit-tests on  different `R`-versions, on three separate operating systems on every push - it is a safe assumption that no breaking bugs will be introduced anytime soon, without it being captured by GHA.  So therefore all tests are skipped on CRAN.

> [!NOTE]
>
> `devtools::check_win_devel()` is **not** run on CRAN.