### PR TITLE
:hammer_and_wrench: MacOS-devel fix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -173,8 +173,24 @@ jobs:
         if: matrix.config.compiler != 'clang'
         shell: Rscript {0}
         run: |
+          # 1) check if OpenMP
+          # is available
+          Rcpp::cppFunction(plugins = "openmp",
+            code = "
+            bool is_available() {
+              #ifdef _OPENMP
+                return true;
+              #else
+                return false;
+              #endif
+            }
+            "
+          )
+
+          # 2) stop if not
+          # available
           stopifnot(
-            "OpenMP not available!" = SLmetrics:::openmp_available()
+            "OpenMP not available!" = is_available()
           )
 
       - name: Setup Python and {reticulate}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -91,6 +91,9 @@ jobs:
 
           # Linker flags
           LDFLAGS=-L\${OMP_LIB} -L${GCC_PATH}/lib -lomp -lgfortran -lm -isysroot ${SDK_PATH}
+          CPPFLAGS += -I$(brew --prefix gettext)/include
+          LDFLAGS  += -L$(brew --prefix gettext)/lib -lintl
+
 
           # Fortran configuration
           FC=$(brew --prefix gfortran)/bin/gfortran
@@ -124,6 +127,8 @@ jobs:
 
           # Linker flags
           LDFLAGS=-L${GCC_PATH}/lib -lgfortran -lm -isysroot ${SDK_PATH}
+          CPPFLAGS += -I$(brew --prefix gettext)/include
+          LDFLAGS  += -L$(brew --prefix gettext)/lib -lintl
 
           # Fortran configuration
           FC=$(brew --prefix gfortran)/bin/gfortran

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,11 +61,6 @@ jobs:
           brew install libomp pkg-config
           brew cleanup
 
-      - name: Install xcode-command tools
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          xcode-select --install
-
       - name: Configure Makevars (macOS-gcc)
         if: runner.os == 'macOS' && matrix.config.compiler == 'gcc'
         run: |
@@ -154,29 +149,10 @@ jobs:
           extra-packages: any::rcmdcheck reticulate
           needs: check
           
-      - name: Check OpenMP availability
-        if: matrix.config.compiler != 'clang'
+      - name: Check if R is properly setup
         shell: Rscript {0}
         run: |
-          # 1) check if OpenMP
-          # is available
-          Rcpp::cppFunction(plugins = "openmp",
-            code = "
-            bool is_available() {
-              #ifdef _OPENMP
-                return true;
-              #else
-                return false;
-              #endif
-            }
-            "
-          )
-
-          # 2) stop if not
-          # available
-          stopifnot(
-            "OpenMP not available!" = is_available()
-          )
+          pkgbuild::check_build_tools(debug = TRUE)
 
       - name: Setup Python and {reticulate}
         uses: ./.github/actions/setup-reticulate

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,6 +61,11 @@ jobs:
           brew install libomp pkg-config
           brew cleanup
 
+      - name: Install xcode-command tools
+        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        run: |
+          xcode-select --install
+
       - name: Configure Makevars (macOS-gcc)
         if: runner.os == 'macOS' && matrix.config.compiler == 'gcc'
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,12 +55,23 @@ jobs:
       - name: Install and update build tools (macOS)
         if: runner.os == 'macOS'
         run: |
+          # update and upgrade
+          # everything brew-related
           brew update
           brew upgrade
+
+          # reinstall important
+          # libraries
           brew reinstall gcc
-          brew install libomp pkg-config gettext
+          brew reinstall pkg-config
+          brew reinstall gettext
+          brew install libomp
+
+          # clean up eveything
           brew cleanup
 
+          # creatre folders
+          # and symbolic links
           sudo mkdir -p /opt/R/arm64/lib
           sudo ln -sf $(brew --prefix gettext)/lib/libintl.a /opt/R/arm64/lib/libintl.a
 
@@ -153,10 +164,18 @@ jobs:
           extra-packages: any::rcmdcheck reticulate
           needs: check
           
-      - name: Check if R is properly setup
+      - name: Check R build-tools
         shell: Rscript {0}
         run: |
           pkgbuild::check_build_tools(debug = TRUE)
+
+      - name: Check OpenMP availability
+        if: matrix.config.compiler != 'clang'
+        shell: Rscript {0}
+        run: |
+          stopifnot(
+            "OpenMP not available!" = SLmetrics:::openmp_available()
+          )
 
       - name: Setup Python and {reticulate}
         uses: ./.github/actions/setup-reticulate

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,8 +58,12 @@ jobs:
           brew update
           brew upgrade
           brew reinstall gcc
-          brew install libomp pkg-config
+          brew install libomp pkg-config gettext
           brew cleanup
+
+          sudo mkdir -p /opt/R/arm64/lib
+          sudo ln -sf $(brew --prefix gettext)/lib/libintl.a /opt/R/arm64/lib/libintl.a
+
 
       - name: Configure Makevars (macOS-gcc)
         if: runner.os == 'macOS' && matrix.config.compiler == 'gcc'


### PR DESCRIPTION
## :books: What?

The `macOS r-devel` were failing due to missing linker-flags to `/opt/R/arm64/lib/libintl.a`. This has been fixed by adding symbolic links to it, and adding it to the `Makevars`. Everything runs smooth for now.